### PR TITLE
#15 공통 인풋 텍스트 필드 제작

### DIFF
--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -37,7 +37,6 @@ fun KeyLinkTextField(
                 onValueChanged(it)
             }
         },
-        maxLines = 2,
         placeholder = { Text(text = hint, fontSize = fontSize.sp, color = Gray04) },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Password,

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -1,0 +1,78 @@
+package com.mashup.presentation.ui.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import com.mashup.presentation.ui.theme.Gray04
+import com.mashup.presentation.ui.theme.Mint
+import com.mashup.presentation.ui.theme.White
+
+@Composable
+fun KeyLinkTextField(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChanged: (String) -> Unit = {},
+    hint: String,
+    onClickDone: () -> Unit = {},
+    fontSize: Int,
+    maxLength: Int = 0
+) {
+    TextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = {
+            if (maxLength > 0 && it.length <= maxLength) {
+                onValueChanged(it)
+            }
+        },
+        maxLines = 2,
+        placeholder = { Text(text = hint, fontSize = fontSize.sp, color = Gray04) },
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Password,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = { onClickDone.invoke() },
+        ),
+        textStyle = TextStyle(
+            fontSize = fontSize.sp,
+            color = White
+        ),
+        colors = TextFieldDefaults.textFieldColors(
+            backgroundColor = Color.Transparent,
+            cursorColor = Mint,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent
+        )
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewKeyLinkTextField() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        var nickname by remember { mutableStateOf("") }
+
+        KeyLinkTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = nickname,
+            onValueChanged = { nickname = it },
+            hint = "닉네임 입력",
+            fontSize = 32,
+            maxLength = 10,
+        )
+    }
+}

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -5,6 +5,6 @@
     <color name="purple_700">#FF3700B3</color>
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
+    <color name="black">#FF0A0C10</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -10,7 +10,8 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">@color/black</item>
         <!-- Customize your theme here. -->
+        <item name="android:windowBackground">@color/black</item>
     </style>
 </resources>


### PR DESCRIPTION
## 작업 내역

- 공통 인풋 텍스트 필드 제작
- 기본 statusbar, background 색 black으로 변경

## 화면
| 기능     | 화면     |
|--------|--------|
| 공통 인풋 텍스트 필드 제작 | ![KakaoTalk_Photo_2023-06-03-22-01-19 002](https://github.com/mash-up-kr/ssam-d-Android/assets/37477660/bfdab241-4d74-47fa-83de-119c5fd72e42) |
|공통 인풋 텍스트 필드 제작|![KakaoTalk_Photo_2023-06-03-22-01-18 001](https://github.com/mash-up-kr/ssam-d-Android/assets/37477660/077f0200-b961-44b7-9fc3-92cdd421c282)|




## 관련 이슈
close #15 