### PR TITLE
#27 ci 빌드를 위한 secrets 세팅

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,16 +45,16 @@ jobs:
 
       # ci 빌드를 위한 secrets 세팅
       - name: Generate file from Github actions secrets
-          env:
-            KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
-            KAKAO_REDIRECTION_SCHEME: ${{ secrets.KAKAO_REDIRECTION_SCHEME }}
-            path: presentation/src/main/res/values/kakao_strings.xml
-          run: |
-            touch $path
-            echo \<resources\> >> $path
-            echo \<string name=\"kakao_native_app_key\"\>$KAKAO_NATIVE_APP_KEY\</string\> >> $path
-            echo \<string name=\"kakao_native_app_key\"\>$KAKAO_REDIRECTION_SCHEME\</string\> >> $path
-            echo \</resources\> >> $path
+        env:
+          KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          KAKAO_REDIRECTION_SCHEME: ${{ secrets.KAKAO_REDIRECTION_SCHEME }}
+          path: presentation/src/main/res/values/kakao_strings.xml
+        run: |
+          touch $path
+          echo \<resources\> >> $path
+          echo \<string name=\"kakao_native_app_key\"\>$KAKAO_NATIVE_APP_KEY\</string\> >> $path
+          echo \<string name=\"kakao_native_app_key\"\>$KAKAO_REDIRECTION_SCHEME\</string\> >> $path
+          echo \</resources\> >> $path
 
       # 최종 빌드
       - name: Build with Gradle

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,6 +43,19 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # ci 빌드를 위한 secrets 세팅
+      - name: Generate file from Github actions secrets
+          env:
+            KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+            KAKAO_REDIRECTION_SCHEME: ${{ secrets.KAKAO_REDIRECTION_SCHEME }}
+            path: presentation/src/main/res/values/kakao_strings.xml
+          run: |
+            touch $path
+            echo \<resources\> >> $path
+            echo \<string name=\"kakao_native_app_key\"\>$KAKAO_NATIVE_APP_KEY\</string\> >> $path
+            echo \<string name=\"kakao_native_app_key\"\>$KAKAO_REDIRECTION_SCHEME\</string\> >> $path
+            echo \</resources\> >> $path
+
       # 최종 빌드
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,7 +53,7 @@ jobs:
           touch $path
           echo \<resources\> >> $path
           echo \<string name=\"kakao_native_app_key\"\>$KAKAO_NATIVE_APP_KEY\</string\> >> $path
-          echo \<string name=\"kakao_native_app_key\"\>$KAKAO_REDIRECTION_SCHEME\</string\> >> $path
+          echo \<string name=\"kakao_redirection_scheme\"\>$KAKAO_REDIRECTION_SCHEME\</string\> >> $path
           echo \</resources\> >> $path
 
       # 최종 빌드


### PR DESCRIPTION
## 작업 내역

- github actions에 native app key를 secrets로 세팅해 ci 빌드 시 값을 가져올 수 있도록 구현

## 화면

<img width="750" alt="image" src="https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/bd848eb0-e8d2-459f-a2ff-99c56216b5c9">



## 관련 이슈
close #27