### PR TITLE
#75 홈 탭 시그널 아이템 구현

### DIFF
--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -71,8 +71,7 @@ private fun HomeScreenToolBar() {
             )
             Text(
                 text = stringResource(id = R.string.home_my_planet, "Æ X-03"),
-                fontSize = 20.sp,
-                fontWeight = FontWeight(600),
+                style = Typography.h4,
                 color = White
             )
         }
@@ -107,7 +106,7 @@ private fun HomeKeywordInfoContainer() {
             )
             Text(
                 text = stringResource(id = R.string.home_subscribe_keywords, 4),
-                fontSize = 14.sp,
+                style = Typography.body2,
                 color = White
             )
         }
@@ -139,8 +138,7 @@ private fun EmptySignal() {
     ) {
         Text(
             text = stringResource(id = R.string.home_planet_guide, "Æ X-03"),
-            fontSize = 16.sp,
-            fontWeight = FontWeight(500),
+            style = Typography.body1,
             color = White,
             textAlign = TextAlign.Center
         )
@@ -179,7 +177,7 @@ private fun SignalCard(signal: SignalUiModel) {
             SignalCardUserInfo(signal)
             Text(
                 text = signal.summery,
-                fontSize = 14.sp,
+                style = Typography.body1,
                 color = White,
                 maxLines = 3
             )
@@ -202,12 +200,12 @@ private fun SignalCardUserInfo(signal: SignalUiModel) {
         )
         Text(
             text = signal.nickname,
-            fontSize = 12.sp,
+            style = Typography.body2,
             color = White
         )
         Text(
             text = signal.getDisplayedTime(),
-            fontSize = 12.sp,
+            style = Typography.caption,
             color = Gray06
         )
     }

--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -148,6 +148,29 @@ private fun EmptySignal() {
 }
 
 @Composable
+private fun SignalCardKeywordsChips(keywords: List<String>) {
+    val maxKeywordCount = 3
+
+    val keywordChipItems = mutableListOf<String>().apply {
+        if (keywords.size > maxKeywordCount) {
+            addAll(keywords.subList(0, maxKeywordCount))
+            add(
+                "+${keywords.size.minus(maxKeywordCount)}"
+            )
+        } else {
+            addAll(keywords)
+        }
+    }
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.Start),
+    ) {
+        items(keywordChipItems.size) {
+            SignalCardKeywordsChip(keyword = keywordChipItems[it])
+        }
+    }
+}
+
+@Composable
 private fun SignalCardKeywordsChip(keyword: String) {
     Box(
         modifier = Modifier

--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -3,6 +3,8 @@ package com.mashup.presentation.home
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
@@ -12,12 +14,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mashup.presentation.R
+import com.mashup.presentation.home.model.SignalUiModel
 import com.mashup.presentation.ui.common.KeyLinkRoundButton
 import com.mashup.presentation.ui.theme.*
 
@@ -148,6 +152,43 @@ private fun EmptySignal() {
 }
 
 @Composable
+private fun SignalCardList() {
+    val signals = emptyList<SignalUiModel>()
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
+        horizontalAlignment = Alignment.Start,
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp)
+    ) {
+        items(signals.size) {
+            SignalCard(signals[it])
+        }
+    }
+}
+
+@Composable
+private fun SignalCard(signal: SignalUiModel) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(shape = RoundedCornerShape(12.dp), color = GrayAlpha20)
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .padding(vertical = 12.dp, horizontal = 16.dp),
+        ) {
+            SignalCardUserInfo(signal)
+            Text(
+                text = signal.summery,
+                fontSize = 14.sp,
+                color = White,
+                maxLines = 3
+            )
+            SignalCardKeywordsChips(signal.keywords)
+        }
+    }
+}
+
 @Composable
 private fun SignalCardUserInfo(signal: SignalUiModel) {
     Row(
@@ -210,11 +251,9 @@ private fun SignalCardKeywordsChip(keyword: String) {
             fontSize = 10.sp,
             color = Gray10,
             textAlign = TextAlign.Center,
-            style = TextStyle(
-                lineHeight = 2.5.em,
-                platformStyle = PlatformTextStyle(
-                    includeFontPadding = false
-                )
+        )
+    }
+}
             )
         )
     }

--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -147,6 +147,29 @@ private fun EmptySignal() {
     }
 }
 
+@Composable
+private fun SignalCardKeywordsChip(keyword: String) {
+    Box(
+        modifier = Modifier
+            .background(color = Gray01, shape = RoundedCornerShape(10.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(vertical = 4.dp, horizontal = 8.dp),
+            text = keyword,
+            fontSize = 10.sp,
+            color = Gray10,
+            textAlign = TextAlign.Center,
+            style = TextStyle(
+                lineHeight = 2.5.em,
+                platformStyle = PlatformTextStyle(
+                    includeFontPadding = false
+                )
+            )
+        )
+    }
+}
 @Preview
 @Composable
 fun PreviewHomeScreen() {

--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -148,6 +148,32 @@ private fun EmptySignal() {
 }
 
 @Composable
+@Composable
+private fun SignalCardUserInfo(signal: SignalUiModel) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            modifier = Modifier.size(24.dp),
+            painter = painterResource(id = R.drawable.img_avatar),
+            contentDescription = "아바타",
+            contentScale = ContentScale.Inside
+        )
+        Text(
+            text = signal.nickname,
+            fontSize = 12.sp,
+            color = White
+        )
+        Text(
+            text = "1일전",
+            fontSize = 12.sp,
+            color = Gray06
+        )
+    }
+}
+
+@Composable
 private fun SignalCardKeywordsChips(keywords: List<String>) {
     val maxKeywordCount = 3
 

--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -197,7 +197,7 @@ private fun SignalCardUserInfo(signal: SignalUiModel) {
         Image(
             modifier = Modifier.size(24.dp),
             painter = painterResource(id = R.drawable.img_avatar),
-            contentDescription = "아바타",
+            contentDescription = stringResource(id = R.string.home_item_avatar_content_description),
             contentScale = ContentScale.Inside
         )
         Text(

--- a/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/HomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -207,7 +206,7 @@ private fun SignalCardUserInfo(signal: SignalUiModel) {
             color = White
         )
         Text(
-            text = "1일전",
+            text = signal.getDisplayedTime(),
             fontSize = 12.sp,
             color = Gray06
         )
@@ -254,10 +253,7 @@ private fun SignalCardKeywordsChip(keyword: String) {
         )
     }
 }
-            )
-        )
-    }
-}
+
 @Preview
 @Composable
 fun PreviewHomeScreen() {

--- a/presentation/src/main/java/com/mashup/presentation/home/model/SignalUiModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/model/SignalUiModel.kt
@@ -1,5 +1,7 @@
 package com.mashup.presentation.home.model
 
+import java.util.concurrent.TimeUnit
+
 /**
  * 임시 data model입니다.
  */
@@ -9,4 +11,32 @@ data class SignalUiModel(
     val summery: String,
     val keywords: List<String>,
     val uploadTime: Long
-)
+) {
+    fun getDisplayedTime(): String {
+        val currentTimeMillis = System.currentTimeMillis()
+        val diffMillis = currentTimeMillis - uploadTime
+
+        return when {
+            diffMillis < TimeUnit.MINUTES.toMillis(1) -> "지금"
+            diffMillis < TimeUnit.HOURS.toMillis(1) -> {
+                val minutes = TimeUnit.MILLISECONDS.toMinutes(diffMillis)
+                "${minutes}분 전"
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(1) -> {
+                val hours = TimeUnit.MILLISECONDS.toHours(diffMillis)
+                "${hours}시간 전"
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(30) -> {
+                val days = TimeUnit.MILLISECONDS.toDays(diffMillis)
+                "${days}일 전"
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(365) -> {
+                val months = (TimeUnit.MILLISECONDS.toDays(diffMillis) / 30).toInt()
+                "${months}달 전"
+            }
+            else -> {
+                "오래 전"
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/mashup/presentation/home/model/SignalUiModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/home/model/SignalUiModel.kt
@@ -1,0 +1,12 @@
+package com.mashup.presentation.home.model
+
+/**
+ * 임시 data model입니다.
+ */
+data class SignalUiModel(
+    val profileImage: String? = null,
+    val nickname: String,
+    val summery: String,
+    val keywords: List<String>,
+    val uploadTime: Long
+)

--- a/presentation/src/main/java/com/mashup/presentation/ui/theme/Color.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/theme/Color.kt
@@ -17,6 +17,7 @@ val Gray07 = Color(0XFF9E9EA3)
 val Gray08 = Color(0XFFB1B1B4)
 val Gray09 = Color(0XFFC3C3C6)
 val Gray10 = Color(0XFFE4E4E5)
+val GrayAlpha20 = Color(0x800A0C10)
 
 // Main
 val Purple = Color(0xFF4D36DA)

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     // 온보딩
     <string name="onboarding_keywords_complete">모두 입력했어요</string>
     <string name="onboarding_keywords_input">대화하고 싶은 키워드를 적어주세요</string>
-    <string name="onboarding_keywords_input_description">입력한 키워드를 기반으로 매칭해드려</string>
+    <string name="onboarding_keywords_input_description">입력한 키워드를 기반으로 매칭해드려요</string>
     <string name="onboarding_keywords_chip_hint">입력한 키워드를 기반으로 매칭해드려요</string>
     <string name="onboarding_delete_keyword_content_description">키워드 지우기</string>
 
@@ -78,4 +78,5 @@
     <string name="home_planet_guide_button">가이드 보기</string>
     <string name="home_signal_icon_content_description">시그널 아이콘</string>
     <string name="home_subscribe_keywords">%d개 키워드 구독중</string>
+    <string name="home_item_avatar_content_description">아바타</string>
 </resources>


### PR DESCRIPTION
## 작업 내역

- 시그널 아이템 ui


## To. Reviewer

- 위로 스크롤될 때 키워드 탭 사라지고 아래로 스크롤될 때 키워드 탭 보이도록 하는 부분 아직 미구현
- blur 미구현

## 화면
| 기능     | 화면     |
|--------|--------|
| 아이템 ui |![KakaoTalk_Photo_2023-06-24-23-48-48](https://github.com/mash-up-kr/ssam-d-Android/assets/37477660/84b9ccb9-ebfc-4359-bd36-0473d6385d21) |


## 관련 이슈
close #75 
