### PR TITLE
#50 닉네임 중복 api 연결

### DIFF
--- a/data/src/main/java/com/mashup/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/data/repository/LoginRepositoryImpl.kt
@@ -4,7 +4,9 @@ import com.mashup.data.source.local.datasource.LocalLoginDataSource
 import com.mashup.data.source.remote.datasource.RemoteLoginDataSource
 import com.mashup.data.source.remote.dto.requestbody.LoginRequestBody
 import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.usecase.ConflictException
 import com.mashup.domain.usecase.LoginParam
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
@@ -31,7 +33,14 @@ class LoginRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getNicknameDuplication(nickname: String) {
-        remoteLoginDataSource.getNicknameDuplicate(nickname)
+        try {
+            remoteLoginDataSource.getNicknameDuplication(nickname)
+        } catch (e: HttpException) {
+            when (e.code()) {
+                409 -> throw ConflictException("ConflictException")
+                else -> throw Exception("Exception")
+            }
+        }
     }
 
     override suspend fun patchNickname(nickname: String) {

--- a/data/src/main/java/com/mashup/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/data/repository/LoginRepositoryImpl.kt
@@ -30,6 +30,10 @@ class LoginRepositoryImpl @Inject constructor(
         return token.isNotEmpty()
     }
 
+    override suspend fun getNicknameDuplication(nickname: String) {
+        remoteLoginDataSource.getNicknameDuplicate(nickname)
+    }
+
     override suspend fun patchNickname(nickname: String) {
         remoteLoginDataSource.patchNickname(nickname)
     }

--- a/data/src/main/java/com/mashup/data/source/remote/datasource/RemoteLoginDataSource.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/datasource/RemoteLoginDataSource.kt
@@ -14,7 +14,7 @@ class RemoteLoginDataSource @Inject constructor(
         return loginService.login(loginRequestBody)
     }
 
-    suspend fun getNicknameDuplicate(nickname: String) {
+    suspend fun getNicknameDuplication(nickname: String) {
         loginService.getNicknameDuplication(nickname)
     }
 

--- a/data/src/main/java/com/mashup/data/source/remote/datasource/RemoteLoginDataSource.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/datasource/RemoteLoginDataSource.kt
@@ -14,6 +14,10 @@ class RemoteLoginDataSource @Inject constructor(
         return loginService.login(loginRequestBody)
     }
 
+    suspend fun getNicknameDuplicate(nickname: String) {
+        loginService.getNicknameDuplication(nickname)
+    }
+
     suspend fun patchNickname(nickname: String) {
         loginService.patchNickname(nickname)
     }

--- a/data/src/main/java/com/mashup/data/source/remote/service/LoginService.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/service/LoginService.kt
@@ -6,8 +6,10 @@ import com.mashup.data.source.remote.dto.responsebody.LoginResponseBody
 import retrofit2.http.Body
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface LoginService {
 
@@ -15,6 +17,11 @@ interface LoginService {
     suspend fun login(
         @Body requestBody: LoginRequestBody
     ): BaseResponse<LoginResponseBody>
+
+    @GET("users/nickname/duplication")
+    suspend fun getNicknameDuplication(
+        @Query("nickname") nickname: String
+    ): BaseResponse<Any>
 
     @FormUrlEncoded
     @PATCH("users/nickname")

--- a/domain/src/main/java/com/mashup/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/mashup/domain/repository/LoginRepository.kt
@@ -4,5 +4,6 @@ import com.mashup.domain.usecase.LoginParam
 
 interface LoginRepository {
     suspend fun login(param: LoginParam): Boolean
+    suspend fun getNicknameDuplication(nickname: String)
     suspend fun patchNickname(nickname: String)
 }

--- a/domain/src/main/java/com/mashup/domain/usecase/CheckNicknameDuplicationUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/CheckNicknameDuplicationUseCase.kt
@@ -1,0 +1,15 @@
+package com.mashup.domain.usecase
+
+import com.mashup.domain.repository.LoginRepository
+import javax.inject.Inject
+
+class CheckNicknameDuplicationUseCase @Inject constructor(
+    private val loginRepository: LoginRepository
+) : BaseUseCase<String, Result<Unit>>() {
+
+    override suspend fun invoke(param: String): Result<Unit> {
+        return runCatching {
+            loginRepository.getNicknameDuplication(param)
+        }
+    }
+}

--- a/domain/src/main/java/com/mashup/domain/usecase/CheckNicknameDuplicationUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/CheckNicknameDuplicationUseCase.kt
@@ -13,3 +13,5 @@ class CheckNicknameDuplicationUseCase @Inject constructor(
         }
     }
 }
+
+class ConflictException(message: String) : Exception(message)

--- a/presentation/src/main/java/com/mashup/presentation/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/presentation/login/LoginActivity.kt
@@ -25,7 +25,7 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setThemeContent {
-            LoginScreen(
+            LoginRoute(
                 loginButtonClicked = { handleKakaoLogin() },
                 loginToOnBoarding = {
                     startActivity(Intent(this, OnBoardingActivity::class.java))

--- a/presentation/src/main/java/com/mashup/presentation/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/login/LoginScreen.kt
@@ -24,7 +24,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.airbnb.lottie.compose.*
 import com.mashup.presentation.R
 import com.mashup.presentation.ui.common.*
@@ -36,12 +37,12 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun LoginRoute(
-    loginViewModel: LoginViewModel = viewModel(),
+    loginViewModel: LoginViewModel = hiltViewModel(),
     loginButtonClicked: () -> Unit,
     loginToOnBoarding: () -> Unit,
     handleOnBackPressed: () -> Unit
 ) {
-    val nicknameState by loginViewModel.nicknameState.collectAsState()
+    val nicknameState by loginViewModel.nicknameState.collectAsStateWithLifecycle()
 
     BackHandler(enabled = true) {
         when (loginViewModel.currentPage) {

--- a/presentation/src/main/java/com/mashup/presentation/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/login/LoginScreen.kt
@@ -34,28 +34,54 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun LoginScreen(
+fun LoginRoute(
     loginViewModel: LoginViewModel = viewModel(),
     loginButtonClicked: () -> Unit,
     loginToOnBoarding: () -> Unit,
     handleOnBackPressed: () -> Unit
 ) {
     val nicknameState by loginViewModel.nicknameState.collectAsState()
-    val coroutineScope = rememberCoroutineScope()
-
-    val pagerState = rememberPagerState(0)
-
-    LaunchedEffect(loginViewModel.currentPage) {
-        pagerState.animateScrollToPage(loginViewModel.currentPage)
-    }
 
     BackHandler(enabled = true) {
         when (loginViewModel.currentPage) {
             0 -> handleOnBackPressed()
             else -> loginViewModel.backToPrevPage()
         }
+    }
+
+    LoginScreen(
+        currentPage = loginViewModel.currentPage,
+        nickname = loginViewModel.nickname,
+        nicknameState = nicknameState,
+        loginButtonClicked = loginButtonClicked,
+        loginToOnBoarding = loginToOnBoarding,
+        patchNickname = { nickname ->
+            loginViewModel.patchNickname(nickname)
+        },
+        getNicknameDuplication = { nickname ->
+            loginViewModel.getNicknameDuplication(nickname)
+        }
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LoginScreen(
+    currentPage: Int,
+    nickname: String,
+    nicknameState: ValidationState,
+    loginButtonClicked: () -> Unit,
+    loginToOnBoarding: () -> Unit,
+    patchNickname: (String) -> Unit,
+    getNicknameDuplication: (String) -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    val pagerState = rememberPagerState(0)
+
+    LaunchedEffect(currentPage) {
+        pagerState.animateScrollToPage(currentPage)
     }
 
     HorizontalPager(
@@ -74,17 +100,17 @@ fun LoginScreen(
             )
             1 -> NicknameScreen(
                 onNextButtonClicked = { nickname ->
-                    loginViewModel.patchNickname(nickname)
+                    patchNickname(nickname)
                 },
                 checkNicknameDuplication = { nickname ->
-                    loginViewModel.getNicknameDuplication(nickname)
+                    getNicknameDuplication(nickname)
                 },
                 validationState = nicknameState,
                 coroutineScope = coroutineScope
             )
             2 -> LoginCompletionScreen (
                 onStartButtonClicked = loginToOnBoarding,
-                nickname = loginViewModel.nickname
+                nickname = nickname
             )
         }
     }

--- a/presentation/src/main/java/com/mashup/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/login/LoginViewModel.kt
@@ -11,8 +11,7 @@ import com.mashup.domain.usecase.LoginUseCase
 import com.mashup.domain.usecase.PatchNicknameUseCase
 import com.mashup.presentation.ui.common.ValidationState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -28,7 +27,7 @@ class LoginViewModel @Inject constructor(
     var nickname by mutableStateOf("")
 
     private val _nicknameState: MutableStateFlow<ValidationState> = MutableStateFlow(ValidationState.EMPTY)
-    val nicknameState: StateFlow<ValidationState> = _nicknameState
+    val nicknameState = _nicknameState.asStateFlow()
 
     private fun goToNextPage() = currentPage++
 
@@ -60,9 +59,7 @@ class LoginViewModel @Inject constructor(
                     Timber.i("중복된 닉네임 없음ㅋ")
                     _nicknameState.value = ValidationState.SUCCESS
                 }.onFailure {
-                    it.message?.let { message ->
-                        Timber.e(message)
-                    }
+                    Timber.e(it.message)
                     _nicknameState.value = ValidationState.FAILED
                 }
         }

--- a/presentation/src/main/java/com/mashup/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/login/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mashup.domain.usecase.CheckNicknameDuplicationUseCase
 import com.mashup.domain.usecase.LoginParam
 import com.mashup.domain.usecase.LoginUseCase
 import com.mashup.domain.usecase.PatchNicknameUseCase
@@ -16,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
+    private val checkNicknameDuplicationUseCase: CheckNicknameDuplicationUseCase,
     private val patchNicknameUseCase: PatchNicknameUseCase
 ): ViewModel() {
 

--- a/presentation/src/main/java/com/mashup/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/login/LoginViewModel.kt
@@ -5,10 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.mashup.domain.usecase.CheckNicknameDuplicationUseCase
-import com.mashup.domain.usecase.LoginParam
-import com.mashup.domain.usecase.LoginUseCase
-import com.mashup.domain.usecase.PatchNicknameUseCase
+import com.mashup.domain.usecase.*
 import com.mashup.presentation.ui.common.ValidationState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -59,8 +56,13 @@ class LoginViewModel @Inject constructor(
                     Timber.i("중복된 닉네임 없음ㅋ")
                     _nicknameState.value = ValidationState.SUCCESS
                 }.onFailure {
-                    Timber.e(it.message)
-                    _nicknameState.value = ValidationState.FAILED
+                    when (it) {
+                        is ConflictException -> {
+                            Timber.e("중복된 닉네임당")
+                            _nicknameState.value = ValidationState.FAILED
+                        }
+                        else -> Timber.e("삐빅- 에러 발생 WHY? " + it.message)
+                    }
                 }
         }
     }


### PR DESCRIPTION
## 작업 내역

-  닉네임 중복 data/domain/presentation layer 구현 및 api 연결

## To. Reviewer

- 중복 에러 상태 코드 받아오는 방법에서 가이드 준 대로 throw Exception("response.statusCode") 이런 형태로 해봤는데.. 이 exception message가 제대로 전달이 안되더라고..? 흑흑
- 그래서 repository에서 HttpException code() 가져와서 ConflictException인지 아닌지 판별하고 에러 던지는 형태로 했어 이 로직을 repository에서 안 하고 ConfliceException class도 만들지 않고 그냥 viewmodel에서 다 처리할 수 있는데 고민하다가 일단 전자 방법으로 해봤어

## 화면
| 기능     | 화면     |
|--------|--------|
|닉네임 중복 확인||

https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/496f5328-d5e0-4230-a487-1b4f065f8794

## 관련 이슈
close #50
