### PR TITLE
마이페이지 api domain, data 레이어 

### DIFF
--- a/data/src/main/java/com/mashup/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/mashup/data/di/RepositoryModule.kt
@@ -16,7 +16,7 @@ interface RepositoryModule {
 
     @Binds
     @Singleton
-    fun bindLoginRepository(loginRepository: UserRepositoryImpl): UserRepository
+    fun bindUserRepository(userRepository: UserRepositoryImpl): UserRepository
 
     @Binds
     @Singleton

--- a/data/src/main/java/com/mashup/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/data/repository/UserRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.mashup.data.source.local.datasource.LocalUserDataSource
 import com.mashup.data.source.remote.datasource.RemoteUserDataSource
 import com.mashup.data.source.remote.dto.requestbody.LoginRequestBody
 import com.mashup.data.util.suspendRunCatching
+import com.mashup.domain.model.User
 import com.mashup.domain.repository.UserRepository
 import com.mashup.domain.usecase.LoginParam
 import javax.inject.Inject
@@ -36,5 +37,19 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun patchNickname(nickname: String) {
         remoteUserDataSource.patchNickname(nickname)
+    }
+
+    override suspend fun patchAlarm(isAgree: Boolean) {
+        remoteLoginDataSource.patchAlarm(isAgree)
+    }
+
+    override suspend fun getUser(id: Long): User {
+        remoteLoginDataSource.getUser(id).let {result ->
+            return result.data?.toDomainModel() ?: throw Exception(result.message)
+        }
+    }
+
+    override suspend fun deleteUser(id: Long) {
+        remoteLoginDataSource.deleteUser(id)
     }
 }

--- a/data/src/main/java/com/mashup/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/data/repository/UserRepositoryImpl.kt
@@ -40,16 +40,16 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun patchAlarm(isAgree: Boolean) {
-        remoteLoginDataSource.patchAlarm(isAgree)
+        remoteUserDataSource.patchAlarm(isAgree)
     }
 
     override suspend fun getUser(id: Long): User {
-        remoteLoginDataSource.getUser(id).let {result ->
+        remoteUserDataSource.getUser(id).let {result ->
             return result.data?.toDomainModel() ?: throw Exception(result.message)
         }
     }
 
     override suspend fun deleteUser(id: Long) {
-        remoteLoginDataSource.deleteUser(id)
+        remoteUserDataSource.deleteUser(id)
     }
 }

--- a/data/src/main/java/com/mashup/data/source/remote/datasource/RemoteUserDataSource.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/datasource/RemoteUserDataSource.kt
@@ -1,7 +1,9 @@
 package com.mashup.data.source.remote.datasource
 
+import com.mashup.data.source.remote.dto.BaseResponse
 import com.mashup.data.source.remote.dto.requestbody.LoginRequestBody
 import com.mashup.data.source.remote.dto.responsebody.LoginResponseBody
+import com.mashup.data.source.remote.dto.responsebody.UserResponseBody
 import com.mashup.data.source.remote.service.UserService
 import javax.inject.Inject
 
@@ -20,5 +22,16 @@ class RemoteUserDataSource @Inject constructor(
 
     suspend fun patchNickname(nickname: String) {
         userService.patchNickname(nickname)
+    }
+    suspend fun patchAlarm(isAgree: Boolean) {
+        userService.patchAlarm(isAgree)
+    }
+
+    suspend fun getUser(id: Long): BaseResponse<UserResponseBody> {
+        return userService.getUser(id)
+    }
+
+    suspend fun deleteUser(id: Long) {
+        userService.deleteUser(id)
     }
 }

--- a/data/src/main/java/com/mashup/data/source/remote/dto/responsebody/UserResponseBody.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/dto/responsebody/UserResponseBody.kt
@@ -1,0 +1,33 @@
+package com.mashup.data.source.remote.dto.responsebody
+
+import com.mashup.domain.base.DomainMapper
+import com.mashup.domain.model.User
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class UserResponseBody (
+    @field:Json(name = "id")
+    val id: Long,
+    @field:Json(name = "nickname")
+    val nickname: String,
+    @field:Json(name = "email")
+    val email: String,
+    @field:Json(name = "provider")
+    val provider: String,
+    @field:Json(name = "profileImageUrl")
+    val profileImageUrl: String,
+    @field:Json(name = "agreeAlarm")
+    val agreeAlarm: Boolean
+): DomainMapper<User> {
+    override fun toDomainModel(): User {
+        return User(
+            id = id,
+            nickname = nickname,
+            email = email,
+            provider = provider,
+            profileImageUrl = profileImageUrl,
+            agreeAlarm = agreeAlarm
+        )
+    }
+}

--- a/data/src/main/java/com/mashup/data/source/remote/service/UserService.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/service/UserService.kt
@@ -33,7 +33,7 @@ interface UserService {
     ): BaseResponse<Any>
 
     @PATCH("users/alarm")
-    suspend fun patchAlarm(
+    suspend fun saveAlarmState(
         @Field("agreeAlarm") agreeAlarm: Boolean
     ): BaseResponse<Any>
 

--- a/data/src/main/java/com/mashup/data/source/remote/service/UserService.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/service/UserService.kt
@@ -33,7 +33,7 @@ interface UserService {
     ): BaseResponse<Any>
 
     @PATCH("users/alarm")
-    suspend fun saveAlarmState(
+    suspend fun patchAlarm(
         @Field("agreeAlarm") agreeAlarm: Boolean
     ): BaseResponse<Any>
 

--- a/data/src/main/java/com/mashup/data/source/remote/service/UserService.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/service/UserService.kt
@@ -3,13 +3,16 @@ package com.mashup.data.source.remote.service
 import com.mashup.data.source.remote.dto.BaseResponse
 import com.mashup.data.source.remote.dto.requestbody.LoginRequestBody
 import com.mashup.data.source.remote.dto.responsebody.LoginResponseBody
+import com.mashup.data.source.remote.dto.responsebody.UserResponseBody
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Query
+import retrofit2.http.Path
 
 interface UserService {
 
@@ -27,5 +30,20 @@ interface UserService {
     @PATCH("users/nickname")
     suspend fun patchNickname(
         @Field("nickname") nickname: String
+    ): BaseResponse<Any>
+
+    @PATCH("users/alarm")
+    suspend fun patchAlarm(
+        @Field("agreeAlarm") agreeAlarm: Boolean
+    ): BaseResponse<Any>
+
+    @GET("users/{id}")
+    suspend fun getUser(
+        @Path("id") id: Long
+    ): BaseResponse<UserResponseBody>
+
+    @DELETE("users/{id}")
+    suspend fun deleteUser(
+        @Path("id") id: Long
     ): BaseResponse<Any>
 }

--- a/domain/src/main/java/com/mashup/domain/base/DomainMapper.kt
+++ b/domain/src/main/java/com/mashup/domain/base/DomainMapper.kt
@@ -1,0 +1,6 @@
+package com.mashup.domain.base
+
+interface DomainMapper<T : DomainModel?> {
+
+    fun toDomainModel(): T
+}

--- a/domain/src/main/java/com/mashup/domain/base/DomainModel.kt
+++ b/domain/src/main/java/com/mashup/domain/base/DomainModel.kt
@@ -1,0 +1,3 @@
+package com.mashup.domain.base
+
+interface DomainModel

--- a/domain/src/main/java/com/mashup/domain/model/User.kt
+++ b/domain/src/main/java/com/mashup/domain/model/User.kt
@@ -1,0 +1,12 @@
+package com.mashup.domain.model
+
+import com.mashup.domain.base.DomainModel
+
+data class User(
+    val id: Long,
+    val nickname: String,
+    val email: String,
+    val provider: String,
+    val profileImageUrl: String,
+    val agreeAlarm: Boolean
+): DomainModel

--- a/domain/src/main/java/com/mashup/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/mashup/domain/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.mashup.domain.repository
 
+import com.mashup.domain.model.User
 import com.mashup.domain.usecase.LoginParam
 
 interface UserRepository {
@@ -8,4 +9,10 @@ interface UserRepository {
     suspend fun getNicknameDuplication(nickname: String): Result<Unit>
 
     suspend fun patchNickname(nickname: String)
+
+    suspend fun patchAlarm(isAgree: Boolean)
+
+    suspend fun getUser(id: Long): User
+
+    suspend fun deleteUser(id: Long)
 }

--- a/domain/src/main/java/com/mashup/domain/usecase/mypage/DeleteUserUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/mypage/DeleteUserUseCase.kt
@@ -1,14 +1,14 @@
 package com.mashup.domain.usecase.mypage
 
-import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.repository.UserRepository
 import com.mashup.domain.usecase.BaseUseCase
 
 class DeleteUserUseCase(
-    private val loginRepository: LoginRepository
+    private val userRepository: UserRepository
 ): BaseUseCase<Long, Result<Unit>>() {
     override suspend fun invoke(param: Long): Result<Unit> {
         return runCatching {
-            loginRepository.deleteUser(id = param)
+            userRepository.deleteUser(id = param)
         }
     }
 }

--- a/domain/src/main/java/com/mashup/domain/usecase/mypage/DeleteUserUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/mypage/DeleteUserUseCase.kt
@@ -1,0 +1,14 @@
+package com.mashup.domain.usecase.mypage
+
+import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.usecase.BaseUseCase
+
+class DeleteUserUseCase(
+    private val loginRepository: LoginRepository
+): BaseUseCase<Long, Result<Unit>>() {
+    override suspend fun invoke(param: Long): Result<Unit> {
+        return runCatching {
+            loginRepository.deleteUser(id = param)
+        }
+    }
+}

--- a/domain/src/main/java/com/mashup/domain/usecase/mypage/GetUserInformationUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/mypage/GetUserInformationUseCase.kt
@@ -1,15 +1,15 @@
 package com.mashup.domain.usecase.mypage
 
 import com.mashup.domain.model.User
-import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.repository.UserRepository
 import com.mashup.domain.usecase.BaseUseCase
 
 class GetUserInformationUseCase(
-    private val loginRepository: LoginRepository
+    private val userRepository: UserRepository
 ): BaseUseCase<Long, Result<User>>() {
     override suspend fun invoke(param: Long): Result<User> {
         return runCatching {
-            loginRepository.getUser(param)
+            userRepository.getUser(param)
         }
     }
 }

--- a/domain/src/main/java/com/mashup/domain/usecase/mypage/GetUserInformationUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/mypage/GetUserInformationUseCase.kt
@@ -1,0 +1,15 @@
+package com.mashup.domain.usecase.mypage
+
+import com.mashup.domain.model.User
+import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.usecase.BaseUseCase
+
+class GetUserInformationUseCase(
+    private val loginRepository: LoginRepository
+): BaseUseCase<Long, Result<User>>() {
+    override suspend fun invoke(param: Long): Result<User> {
+        return runCatching {
+            loginRepository.getUser(param)
+        }
+    }
+}

--- a/domain/src/main/java/com/mashup/domain/usecase/mypage/SaveAlarmStateUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/mypage/SaveAlarmStateUseCase.kt
@@ -1,0 +1,14 @@
+package com.mashup.domain.usecase.mypage
+
+import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.usecase.BaseUseCase
+
+class SaveAlarmStateUseCase(
+    private val loginRepository: LoginRepository
+): BaseUseCase<Boolean, Result<Unit>>() {
+    override suspend fun invoke(param: Boolean): Result<Unit> {
+        return runCatching {
+            loginRepository.saveAlarmState(isAgree = param)
+        }
+    }
+}

--- a/domain/src/main/java/com/mashup/domain/usecase/mypage/SaveAlarmStateUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/mypage/SaveAlarmStateUseCase.kt
@@ -1,14 +1,14 @@
 package com.mashup.domain.usecase.mypage
 
-import com.mashup.domain.repository.LoginRepository
+import com.mashup.domain.repository.UserRepository
 import com.mashup.domain.usecase.BaseUseCase
 
 class SaveAlarmStateUseCase(
-    private val loginRepository: LoginRepository
+    private val userRepository: UserRepository
 ): BaseUseCase<Boolean, Result<Unit>>() {
     override suspend fun invoke(param: Boolean): Result<Unit> {
         return runCatching {
-            loginRepository.saveAlarmState(isAgree = param)
+            userRepository.patchAlarm(isAgree = param)
         }
     }
 }


### PR DESCRIPTION
## 작업 내역

- 마이페이지 api domain, data 레이어 작업

## To. Reviewer
DomainModel, DomainMapper 베이스 코드를 작성했습니다.

- DomainModel: 도메인모델을 한정해주는 interface
- DomainMapper:  DomainModel을 매핑해주는 메서드를 가지고 있는 인터페이스, dto에 상속받아 사용하면 됩니다.

## 화면
| 기능     | 화면     |
|--------|--------|
| Sample | Sample |


## 관련 이슈
close #135 
