### PR TITLE
#81 빌드타입 별 HTTP 로그 출력 및 토큰 인터셉터 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,6 @@ plugins {
     id 'com.google.dagger.hilt.android'
 }
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-
 android {
     namespace 'com.mashup.ssamd'
     compileSdk 33

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,9 @@ plugins {
     id 'com.google.dagger.hilt.android'
 }
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
 android {
     namespace 'com.mashup.ssamd'
     compileSdk 33
@@ -27,9 +30,23 @@ android {
     }
 
     buildTypes {
-        release {
+        debug {
+            debuggable true
             minifyEnabled false
+            manifestPlaceholders = ["appName":"@string/app_name_debug"]
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            applicationIdSuffix '.debug'
+
+            buildConfigField "boolean","IS_DEBUG","true"
+        }
+
+        release {
+            debuggable false
+            minifyEnabled true
+            manifestPlaceholders = ["appName":"@string/app_name"]
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            buildConfigField "boolean","IS_DEBUG","false"
         }
     }
     compileOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ssam_D_Android"
         tools:targetApi="31" />

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -21,9 +21,17 @@ android {
     }
 
     buildTypes {
-        release {
+        debug {
+            debuggable true
             minifyEnabled false
+            buildConfigField "boolean","IS_DEBUG","true"
+        }
+        release {
+            debuggable false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            buildConfigField "boolean","IS_DEBUG","false"
         }
     }
     compileOptions {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="app_name">Ssam_D_Android</string>
+    <string name="app_name">키링</string>
+    <string name="app_name_debug">D_키링</string>
     <string name="empty_text" />
 
     <string name="navigation_home">홈</string>


### PR DESCRIPTION
## 작업 내역

- debug 모드에서만 Http로그 출력하도록 추가
- 빌드타입 별 앱 네이밍 분리
- 토큰 인터셉터 수정

## To. Reviewer

- BuildConfig에서 빌드타입을 판단하여 debug 모드에서만 로그 출력하도록 HttpLoggingInterceptor 추가했습니당.
- 스크립트 수정하는 김에 app_name도 같이 슬쩍 했습니다 ㅎ
- token을 가져오는 메서드를 IO Dispatcher에서 수행하도록 수정했습니당

## 관련 이슈
- #81 
- not close
