### PR TITLE
텍스트필드 관련 이슈 해결

### DIFF
--- a/presentation/src/main/java/com/mashup/presentation/feature/reply/ReplyScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/reply/ReplyScreen.kt
@@ -162,7 +162,6 @@ fun ReplyContent(
             },
             hint = stringResource(id = R.string.hint_signal_content),
             hintAlign = TextAlign.Start,
-            onClickDone = { /*TODO*/ },
             maxLength = 300
         )
         KeyLinkButton(

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
@@ -118,7 +118,6 @@ fun SignalContent(
             },
             hint = stringResource(id = R.string.hint_signal_content),
             hintAlign = TextAlign.Start,
-            onClickDone = { /*TODO*/ },
             maxLength = 300
         )
         KeyLinkButton(

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -32,8 +32,7 @@ fun KeyLinkTextField(
     onValueChange: (String) -> Unit,
     hint: String,
     hintAlign: TextAlign = TextAlign.Center,
-    onClickDone: () -> Unit,
-    maxLength: Int = 0
+    maxLength: Int = 0,
 ) {
     TextField(
         modifier = modifier,
@@ -53,10 +52,6 @@ fun KeyLinkTextField(
         },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Password,
-            imeAction = ImeAction.Done
-        ),
-        keyboardActions = KeyboardActions(
-            onDone = { onClickDone.invoke() },
         ),
         textStyle = Body1.copy(color = White),
         colors = TextFieldDefaults.textFieldColors(
@@ -242,7 +237,6 @@ fun PreviewKeyLinkTextField() {
             onValueChange = { nickname = it },
             hint = "닉네임 입력",
             maxLength = 10,
-            onClickDone = {}
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -94,7 +94,13 @@ fun KeyLinkOnBoardingTextField(
         BasicTextField(
             value = value,
             onValueChange = {
-                // 띄어쓰기 제거
+                // 스페이스일 경우 onClickDone
+                if (it.contains("\\s".toRegex())) {
+                    if (value.length >= minLength) {
+                        onClickDone()
+                        return@BasicTextField
+                    }
+                }
                 val noSpaceText = it.replace("\\s".toRegex(), "")
                 if (maxLength == 0 || noSpaceText.length <= maxLength) {
                     onValueChange(noSpaceText)

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -114,7 +114,10 @@ fun KeyLinkOnBoardingTextField(
                     }
                 }
             ),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done
+            ),
             decorationBox = { innerTextField ->
                 if (value.isEmpty()) {
                     Text(


### PR DESCRIPTION
## 작업 내역

- [온보딩 키워드 입력시 밑줄 없애기](https://github.com/mash-up-kr/ssam-d-Android/commit/b9dca741080cda30f9857f563cfaf0c134710e15)
- [스페이스 이벤트 감지해서 완료처리](https://github.com/mash-up-kr/ssam-d-Android/commit/cf7aab55d4a4a8d900957d1013ff34495e988de3)
- [답장하기, 시그널 생성 텍스트필드 엔터불가능 이슈](https://github.com/mash-up-kr/ssam-d-Android/commit/aa723a789bb798266a2abcd4a05806cc09d9c3f3)

## To. Reviewer

- 스페이스 이벤트 onKeyEvent 동작 안먹어서 onValueChanged에서 처리함. 

## 화면
| 기능     | 화면     |
|--------|--------|
| 스페이스 이벤트 감지 |https://github.com/mash-up-kr/ssam-d-Android/assets/37477660/a0babb80-3763-447a-baa0-8ee03a4f2062|


## 관련 이슈
close #204 
close #169 
close #203 



