### PR TITLE
#229 실시간 네트워크 상태 감지 및 네트워크 에러 스크린 생성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "com.mashup.ssamd"
-        minSdk 23
+        minSdk 24
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -13,7 +13,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
         targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -14,7 +14,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
         targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
         <activity
             android:name=".navigation.MainActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize" />
+
         <activity
             android:name=".feature.onboarding.OnBoardingActivity"
             android:exported="false"
             android:windowSoftInputMode="adjustResize" />
+
+        <activity
+            android:name=".feature.error.NetworkErrorActivity"
+            android:exported="false" />
 
         <activity
             android:name=".feature.login.LoginActivity"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
         <activity
             android:name=".navigation.MainActivity"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
         <activity
             android:name=".navigation.MainActivity"

--- a/presentation/src/main/java/com/mashup/presentation/common/base/BaseActivity.kt
+++ b/presentation/src/main/java/com/mashup/presentation/common/base/BaseActivity.kt
@@ -1,10 +1,20 @@
 package com.mashup.presentation.common.base
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.mashup.presentation.common.network.NetworkStatus
+import com.mashup.presentation.common.network.NetworkStatusMonitor
+import com.mashup.presentation.feature.error.NetworkErrorActivity
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 /**
  * Ssam_D_Android
@@ -14,10 +24,12 @@ import androidx.databinding.ViewDataBinding
 open class BaseActivity<VB : ViewDataBinding>(@LayoutRes private val layoutId: Int) :
     AppCompatActivity() {
 
+    private val networkStatusMonitor by lazy { NetworkStatusMonitor(this) }
     lateinit var binding: VB
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initObservers()
         binding = DataBindingUtil.setContentView(this, layoutId)
 
         initViews()
@@ -25,4 +37,21 @@ open class BaseActivity<VB : ViewDataBinding>(@LayoutRes private val layoutId: I
 
     /* must implement */
     open fun initViews() {}
+
+    private fun initObservers() {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                networkStatusMonitor.networkStatus.collectLatest { networkStatus ->
+                    when (networkStatus) {
+                        is NetworkStatus.NetworkConnected -> {}
+                        is NetworkStatus.NetworkDisconnected -> onNetworkDisconnected()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onNetworkDisconnected() {
+        startActivity(Intent(this, NetworkErrorActivity::class.java))
+    }
 }

--- a/presentation/src/main/java/com/mashup/presentation/common/network/NetworkStatus.kt
+++ b/presentation/src/main/java/com/mashup/presentation/common/network/NetworkStatus.kt
@@ -1,0 +1,11 @@
+package com.mashup.presentation.common.network
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/23
+ */
+sealed class NetworkStatus() {
+    object NetworkConnected : NetworkStatus()
+    object NetworkDisconnected : NetworkStatus()
+}

--- a/presentation/src/main/java/com/mashup/presentation/common/network/NetworkStatusMonitor.kt
+++ b/presentation/src/main/java/com/mashup/presentation/common/network/NetworkStatusMonitor.kt
@@ -1,0 +1,61 @@
+package com.mashup.presentation.common.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.*
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/23
+ */
+class NetworkStatusMonitor(
+    context: Context,
+    private val coroutineScope: CoroutineScope
+) {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    val networkStatus = callbackFlow<NetworkStatus> {
+        val networkStatusCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                trySend(NetworkStatus.NetworkConnected)
+            }
+
+            override fun onLost(network: Network) {
+                trySend(NetworkStatus.NetworkDisconnected)
+            }
+
+            override fun onUnavailable() {
+                trySend(NetworkStatus.NetworkDisconnected)
+            }
+        }
+
+        register(networkStatusCallback)
+
+        awaitClose {
+            unregister(networkStatusCallback)
+        }
+    }.distinctUntilChanged()
+
+    private fun register(networkStatusCallback: ConnectivityManager.NetworkCallback) {
+        connectivityManager.registerDefaultNetworkCallback(networkStatusCallback)
+    }
+
+    private fun unregister(networkStatusCallback: ConnectivityManager.NetworkCallback) {
+        connectivityManager.unregisterNetworkCallback(networkStatusCallback)
+    }
+}
+
+inline fun <R> Flow<NetworkStatus>.map(
+    crossinline onDisconnected: suspend () -> R,
+    crossinline onConnected: suspend () -> R,
+): Flow<R> = map { status ->
+    when (status) {
+        NetworkStatus.NetworkDisconnected -> onDisconnected()
+        NetworkStatus.NetworkConnected -> onConnected()
+    }
+}

--- a/presentation/src/main/java/com/mashup/presentation/common/network/NetworkStatusMonitor.kt
+++ b/presentation/src/main/java/com/mashup/presentation/common/network/NetworkStatusMonitor.kt
@@ -12,10 +12,7 @@ import kotlinx.coroutines.flow.*
  * @author jaesung
  * @created 2023/07/23
  */
-class NetworkStatusMonitor(
-    context: Context,
-    private val coroutineScope: CoroutineScope
-) {
+class NetworkStatusMonitor(context: Context) {
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 

--- a/presentation/src/main/java/com/mashup/presentation/feature/error/ErrorScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/error/ErrorScreen.kt
@@ -1,0 +1,97 @@
+package com.mashup.presentation.feature.error
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.presentation.R
+import com.mashup.presentation.ui.common.KeyLinkButton
+import com.mashup.presentation.ui.common.KeyLinkToolbar
+import com.mashup.presentation.ui.theme.Black
+import com.mashup.presentation.ui.theme.Body2
+import com.mashup.presentation.ui.theme.Gray10
+import com.mashup.presentation.ui.theme.SsamDTheme
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/23
+ */
+@Composable
+fun NetworkErrorScreen(
+    onBackClick: () -> Unit,
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier,
+        backgroundColor = Black,
+        topBar = {
+            KeyLinkToolbar(
+                onClickBack = onBackClick
+            )
+        }
+    ) { paddingValues ->
+        val innerPadding =
+            PaddingValues(top = paddingValues.calculateTopPadding(), start = 20.dp, end = 20.dp)
+
+        ErrorContent(
+            modifier = Modifier.padding(innerPadding),
+            onButtonClick = onButtonClick
+        )
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_error),
+            contentDescription = stringResource(R.string.content_description_error),
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = stringResource(R.string.network_error_title),
+            style = Body2,
+            color = Gray10,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(62.dp))
+
+        KeyLinkButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.button_go_back),
+            onClick = onButtonClick,
+            enable = true
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ErrorScreenPreview() {
+    SsamDTheme {
+        NetworkErrorScreen(
+            onBackClick = {},
+            onButtonClick = {}
+        )
+    }
+}

--- a/presentation/src/main/java/com/mashup/presentation/feature/error/NetworkErrorActivity.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/error/NetworkErrorActivity.kt
@@ -1,0 +1,50 @@
+package com.mashup.presentation.feature.error
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.mashup.presentation.common.extension.setThemeContent
+import com.mashup.presentation.common.network.NetworkStatus
+import com.mashup.presentation.common.network.NetworkStatusMonitor
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/23
+ */
+class NetworkErrorActivity : ComponentActivity() {
+    private val networkStatusMonitor by lazy { NetworkStatusMonitor(this) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        initObservers()
+        super.onCreate(savedInstanceState)
+
+        setThemeContent {
+            NetworkErrorScreen(
+                onBackClick = {},
+                onButtonClick = {}
+            )
+        }
+    }
+
+    private fun initObservers() {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                networkStatusMonitor.networkStatus.collectLatest { networkStatus ->
+                    when (networkStatus) {
+                        is NetworkStatus.NetworkConnected -> onNetworkConnected()
+                        is NetworkStatus.NetworkDisconnected -> {}
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onNetworkConnected() {
+        finish()
+    }
+}

--- a/presentation/src/main/java/com/mashup/presentation/navigation/MainActivity.kt
+++ b/presentation/src/main/java/com/mashup/presentation/navigation/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.mashup.presentation.navigation
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -10,6 +11,7 @@ import com.mashup.presentation.KeyLinkApp
 import com.mashup.presentation.common.extension.setThemeContent
 import com.mashup.presentation.common.network.NetworkStatus
 import com.mashup.presentation.common.network.NetworkStatusMonitor
+import com.mashup.presentation.feature.error.NetworkErrorActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -21,12 +23,7 @@ import kotlinx.coroutines.launch
  */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    private val networkStatusMonitor: NetworkStatusMonitor by lazy {
-        NetworkStatusMonitor(
-            context = this,
-            coroutineScope = lifecycleScope
-        )
-    }
+    private val networkStatusMonitor by lazy { NetworkStatusMonitor(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,55 +36,18 @@ class MainActivity : ComponentActivity() {
 
     private fun initObservers() {
         lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
                 networkStatusMonitor.networkStatus.collectLatest { networkStatus ->
                     when (networkStatus) {
-                        is NetworkStatus.NetworkConnected -> Log.e("NETWORK", "연결")
-                        is NetworkStatus.NetworkDisconnected -> Log.e("NETWORK", "연결끊김")
+                        is NetworkStatus.NetworkConnected -> {}
+                        is NetworkStatus.NetworkDisconnected -> onNetworkDisconnected()
                     }
                 }
             }
         }
     }
+
+    private fun onNetworkDisconnected() {
+        startActivity(Intent(this, NetworkErrorActivity::class.java))
+    }
 }
-
-
-//class HomeActivity : BaseActivity<ActivityHomeBinding>(R.layout.activity_home) {
-//    private val navHostFragment by lazy {
-//        supportFragmentManager.findFragmentById(binding.fcvHome.id) as NavHostFragment
-//    }
-//    private val navController by lazy { navHostFragment.navController }
-//
-//    override fun initViews() {
-//        initBottomNavigationView()
-//        initDestinationChangeListener()
-//    }
-//
-//    private fun initBottomNavigationView() {
-//        binding.bnvHome.setupWithNavController(navController)
-//        addSignalIconItemView()
-//        binding.bnvHome.addBadge(this, 1000)
-//    }
-//
-//    private fun initDestinationChangeListener() {
-//        navController.addOnDestinationChangedListener { _, destination, _ ->
-//            binding.bnvHome.visibility = when (destination.id) {
-//                /* 디자인 명세에 따라 수정 */
-//                R.id.homeFragment -> View.VISIBLE
-//                R.id.chatFragment -> {
-//                    binding.bnvHome.removeBadge()
-//                    View.VISIBLE
-//                }
-//                else -> View.GONE
-//            }
-//        }
-//    }
-//
-//    private fun addSignalIconItemView() {
-//        val navigationMenuView = binding.bnvHome.getChildAt(0) as BottomNavigationMenuView
-//        val navigationItemView = navigationMenuView.getChildAt(1) as BottomNavigationItemView
-//        val signalItemView = LayoutInflater.from(this)
-//            .inflate(R.layout.menu_bottom_navigation_signal, binding.bnvHome, false)
-//        navigationItemView.addView(signalItemView)
-//    }
-//}

--- a/presentation/src/main/res/drawable/ic_error.xml
+++ b/presentation/src/main/res/drawable/ic_error.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="76dp"
+    android:height="67dp"
+    android:viewportWidth="76"
+    android:viewportHeight="67">
+    <path
+        android:fillColor="#7E7E86"
+        android:pathData="M29.005,5.589C32.84,-0.842 42.18,-0.842 46.014,5.589L73.606,51.866C77.525,58.439 72.773,66.766 65.102,66.766H9.918C2.247,66.766 -2.506,58.439 1.414,51.866L29.005,5.589Z" />
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M41.924,22.766H34.01L35.988,45.447H39.946L41.924,22.766Z" />
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M40.935,51.364C40.935,52.998 39.606,54.322 37.967,54.322C36.328,54.322 34.999,52.998 34.999,51.364C34.999,49.73 36.328,48.405 37.967,48.405C39.606,48.405 40.935,49.73 40.935,51.364Z" />
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -130,4 +130,8 @@
     <string name="snackbar_subscribe_keyword">구독 키워드가 저장되었습니다.</string>
     <string name="snackbar_reply">시그널에 대한 답장을 보냈습니다.</string>
     <string name="snackbar_report">신고가 접수되었습니다.</string>
+
+    <string name="content_description_error">에러 아이콘입니다.</string>
+    <string name="network_error_title">네트워크 연결이 되지 않았어요\n다시 시도해주세요</string>
+    <string name="button_go_back">이전으로 돌아가기</string>
 </resources>


### PR DESCRIPTION
## 작업 내역

- #229 
- #234 

## To. Reviewer

- 3가지 확인 필요합니다.
  1. Wifi, LTE 둘다 OFF -> 에러 스크린
  2. Wifi 만 ON -> 정상
  3. LTE, Wifi 둘다 ON (기본값 LTE) -> 정상
- 에러스크린에서는 Back클릭 시 이전 스크린으로 돌아가긴 합니다. 대신 Network off 상태라 앱 사용 불가입니당
- 실시간 감지라 네트워크 상태 변화 시 자동으로 화면 전환되도록 구현해놨습니당

## 화면
| 기능     | 화면     |
|--------|--------|
| Online -> Offline | <img src="https://github.com/mash-up-kr/ssam-d-Android/assets/51078673/32644150-590d-4854-aef4-570d29e7c692" width=300 /> |
| Offline -> Online | <img src="https://github.com/mash-up-kr/ssam-d-Android/assets/51078673/179a5b83-b500-4f4f-ba9f-05c79a8eedbd" width=300 /> |



## 관련 이슈
close #229 
