### PR TITLE
#224 #239 #244 이슈 수정

### DIFF
--- a/data/src/main/java/com/mashup/data/util/Paging.kt
+++ b/data/src/main/java/com/mashup/data/util/Paging.kt
@@ -12,12 +12,13 @@ import com.mashup.domain.base.paging.PagedData
  */
 
 fun <T : Any> createPager(
-    pageSize: Int = 5,
+    pageSize: Int = 10,
     executor: suspend (Int, Int?) -> PagedData<List<T>>
 ): Pager<Int, T> = Pager(
     config = PagingConfig(
         pageSize = pageSize,
-        enablePlaceholders = false
+        enablePlaceholders = false,
+        initialLoadSize = 10
     ),
     pagingSourceFactory = { KeyLinkPagingSource(executor) }
 )

--- a/domain/src/main/java/com/mashup/domain/usecase/login/GetEntryScreenTypeUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/login/GetEntryScreenTypeUseCase.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
  * @created 2023/07/20
  */
 
-class GetFirstEntryScreenTypeUseCase @Inject constructor(
+class GetEntryScreenTypeUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) : CoroutineUseCase<Unit, ScreenType>() {
     override suspend fun invoke(param: Unit): ScreenType {

--- a/presentation/src/main/java/com/mashup/presentation/common/extension/Long.kt
+++ b/presentation/src/main/java/com/mashup/presentation/common/extension/Long.kt
@@ -38,11 +38,11 @@ fun Long.getDisplayedTime(): String {
 }
 
 fun Long.getDisplayedDate(): String {
-    val formatter = SimpleDateFormat("yyyy년 M월 d일", Locale.KOREA)
+    val formatter = SimpleDateFormat("yyyy년 M월 d일 HH:mm", Locale.KOREA)
     return formatter.format(Date(this))
 }
 
 fun Long.getDisplayedDateWithDay(): String {
-    val formatter = SimpleDateFormat("yyyy년 M월 d일 E요일", Locale.KOREA)
+    val formatter = SimpleDateFormat("yyyy년 M월 d일 E요일 HH:mm", Locale.KOREA)
     return formatter.format(Date(this))
 }

--- a/presentation/src/main/java/com/mashup/presentation/common/extension/Modifier.kt
+++ b/presentation/src/main/java/com/mashup/presentation/common/extension/Modifier.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,7 +17,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.*
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -108,5 +107,18 @@ internal fun Modifier.drawColoredShadow(
             shadowColor
         )
         it.drawPath(resultPath, paint)
+    }
+}
+
+internal fun Modifier.visible(visible: Boolean) = if (visible) this else this.then(Invisible)
+
+private object Invisible : LayoutModifier {
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {}
     }
 }

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/message/compose/MessageDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/message/compose/MessageDetailScreen.kt
@@ -134,7 +134,7 @@ private fun MessageDetailContent(
 
         if (messageDetail.isReplyable) {
             KeyLinkRoundButton(
-                modifier = Modifier.padding(top = 16.dp, bottom = 40.dp).align(Alignment.CenterHorizontally),
+                modifier = Modifier.padding(top = 16.dp, bottom = 40.dp, end = 20.dp).align(Alignment.CenterHorizontally),
                 text = stringResource(R.string.button_send_reply),
                 onClick = onReplyButtonClick
             )

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/message/compose/MessageDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/message/compose/MessageDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mashup.presentation.R
 import com.mashup.presentation.common.extension.getDisplayedDateWithDay
+import com.mashup.presentation.common.extension.visible
 import com.mashup.presentation.feature.detail.ChatDetailViewModel
 import com.mashup.presentation.feature.detail.chat.compose.MessageDetailUiState
 import com.mashup.presentation.feature.detail.message.model.MessageDetailUiModel
@@ -132,16 +133,16 @@ private fun MessageDetailContent(
             matchedKeywords = messageDetail.keywords
         )
 
-        if (messageDetail.isReplyable) {
-            KeyLinkRoundButton(
-                modifier = Modifier.padding(top = 16.dp, bottom = 40.dp, end = 20.dp).align(Alignment.CenterHorizontally),
-                text = stringResource(R.string.button_send_reply),
-                onClick = onReplyButtonClick
-            )
-        }
+        KeyLinkRoundButton(
+            modifier = Modifier
+                .padding(top = 16.dp, bottom = 40.dp, end = 20.dp)
+                .align(Alignment.CenterHorizontally)
+                .visible(messageDetail.isReplyable),
+            text = stringResource(R.string.button_send_reply),
+            onClick = onReplyButtonClick
+        )
     }
 }
-
 
 @Preview(showBackground = true)
 @Composable

--- a/presentation/src/main/java/com/mashup/presentation/feature/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/login/LoginViewModel.kt
@@ -19,11 +19,11 @@ class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
     private val checkNicknameDuplicationUseCase: CheckNicknameDuplicationUseCase,
     private val patchNicknameUseCase: PatchNicknameUseCase,
-    private val getFirstEntryScreenTypeUseCase: GetFirstEntryScreenTypeUseCase,
+    private val getEntryScreenTypeUseCase: GetEntryScreenTypeUseCase
 ) : ViewModel() {
 
     init {
-        initScreenType()
+        checkScreenType()
     }
 
     var currentPage by mutableStateOf(0)
@@ -40,9 +40,9 @@ class LoginViewModel @Inject constructor(
 
     fun backToPrevPage() = currentPage--
 
-    private fun initScreenType() {
+    private fun checkScreenType() {
         viewModelScope.launch {
-            when (getFirstEntryScreenTypeUseCase.execute(Unit)) {
+            when (getEntryScreenTypeUseCase.execute(Unit)) {
                 ScreenType.LOGIN -> _loginUiState.emit(LoginUiState.LOGIN)
                 ScreenType.NICKNAME -> _loginUiState.emit(LoginUiState.NICKNAME)
                 ScreenType.KEYWORD -> _loginUiState.emit(LoginUiState.KEYWORD)
@@ -56,7 +56,7 @@ class LoginViewModel @Inject constructor(
             val param = LoginParam(email = email, socialId = socialId, deviceToken = deviceToken)
             loginUseCase.execute(param)
                 .onSuccess {
-                    goToNextPage()
+                    checkScreenType()
                 }.onFailure {}
         }
     }

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/received/ReceivedSignalDetailRoute.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/received/ReceivedSignalDetailRoute.kt
@@ -129,7 +129,7 @@ private fun ReceivedSignalDetailContent(
             matchedKeywords = receivedSignalDetail.keywords
         )
         KeyLinkRoundButton(
-            modifier = Modifier.padding(top = 16.dp, bottom = 40.dp).align(Alignment.CenterHorizontally),
+            modifier = Modifier.padding(top = 16.dp, bottom = 40.dp, end = 20.dp).align(Alignment.CenterHorizontally),
             text = stringResource(R.string.button_send_reply),
             onClick = { onReplyButtonClick(receivedSignalDetail.signalId) }
         )


### PR DESCRIPTION
## 작업 내역

- 페이징 length 10으로 고정 (임시)
- 메세지 상세 ui 이슈
- 로그인 화면 천이 로직 수정
- 날짜 보여주는 부분에 시간 추가

## To. Reviewer

- none

## 화면
| 기능     | 화면     |
|--------|--------|
|메세지 상세 ui 이슈 수정|👇 |

https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/77baa337-dfd4-4da4-8f63-23ce1ed70666

로그인 화면 천이 로직 수정 👇 

https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/9a5bf14a-6c8a-4a84-9fb5-c25229f469b4

날짜 보이는 부분에 시간 추가 👇 

https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/e4b2db35-ea66-426e-a1a0-1753b245c19f


## 관련 이슈
close #224 
close #239 
close #244 
