### PR TITLE
#249 compose-metrics, compose-reports 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .gradle/
 build/
 
+# compose-metrics, compose-reports
+report/
+
 # Local configuration file (sdk path, etc)
 local.properties
 

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -33,6 +33,14 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs += [
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${rootProject.file(".").absolutePath}/report/compose-metrics"
+        ]
+        freeCompilerArgs += [
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${rootProject.file(".").absolutePath}/report/compose-reports"
+        ]
     }
     buildFeatures {
         dataBinding true


### PR DESCRIPTION
## 작업 내역

- 컴포즈 디버깅을 위한 compose-metrics, compose-reports 세팅

## To. Reviewer

- UI 성능개선 작업을 위해 디버깅 툴 추가했습니당
- 만들어진 report들 확인해봤는데 신기방기
- 아래에 참고할 자료들 남겨뒀습니당
  - https://velog.io/@ams770/jetpack-compose-skippable-issue-2-metrics
  - https://sungbin.land/jetpack-compose-%EC%BB%B4%ED%8C%8C%EC%9D%BC%EB%9F%AC-%EB%94%94%EB%B2%84%EA%B9%85-cf21ce431387
  - https://skyyo.medium.com/performance-in-jetpack-compose-9a85ce02f8f9

## 관련 이슈
close #249 
