### PR TITLE
페이징 버그

### DIFF
--- a/data/src/main/java/com/mashup/data/source/remote/source/paging/KeyLinkPagingSource.kt
+++ b/data/src/main/java/com/mashup/data/source/remote/source/paging/KeyLinkPagingSource.kt
@@ -28,6 +28,8 @@ class KeyLinkPagingSource<T : Any> (
             val result = executor.invoke(page, loadSize)
             val isLastPage = (page == result.paging?.totalPage) || (result.paging?.totalPage == 0)
 
+            if (result.data.isEmpty()) return LoadResult.Error(EmptyListException)
+
             LoadResult.Page(
                 data = result.data,
                 prevKey = if (page == INITIAL_PAGE) null else page - 1,
@@ -37,6 +39,9 @@ class KeyLinkPagingSource<T : Any> (
             LoadResult.Error(e)
         }
     }
+
+    object EmptyListException: Exception()
+
 
     companion object {
         private const val INITIAL_PAGE = 1

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
@@ -49,9 +49,6 @@ fun ChatRoute(
             pagedChatRoomList.refresh()
         })
 
-    LaunchedEffect(Unit) {
-        viewModel.getChatRooms()
-    }
     LaunchedEffect(pagedChatRoomList.loadState) {
         if (pagedChatRoomList.loadState.refresh is LoadState.NotLoading)
             isRefreshing = false

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
@@ -48,19 +48,29 @@ fun ChatRoute(
             isRefreshing = true
             pagedChatRoomList.refresh()
         })
+    var isChatRoomEmpty by remember { mutableStateOf(false) }
 
     LaunchedEffect(pagedChatRoomList.loadState) {
-        if (pagedChatRoomList.loadState.refresh is LoadState.NotLoading)
+        if (pagedChatRoomList.loadState.refresh is LoadState.NotLoading) {
             isRefreshing = false
+            isChatRoomEmpty = false
+        }
+
+        if (pagedChatRoomList.loadState.refresh is LoadState.Error) {
+            isChatRoomEmpty = true
+        }
     }
 
     BackHandler(true) {
         onBackClick()
     }
 
-    Box(modifier = Modifier
-        .pullRefresh(pullRefreshState)
-        .fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+    Box(
+        modifier = Modifier
+            .pullRefresh(pullRefreshState)
+            .fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
         ChatScreen(
             modifier = modifier,
             onEmptyScreenButtonClick = onEmptyScreenButtonClick,
@@ -68,7 +78,8 @@ fun ChatRoute(
                 onChatRoomClick(chatId)
             },
             controlBottomSheet = controlBottomSheet,
-            chatRoomList = pagedChatRoomList
+            chatRoomList = pagedChatRoomList,
+            isChatRoomEmpty = isChatRoomEmpty
         )
         PullRefreshIndicator(refreshing = isRefreshing, state = pullRefreshState)
     }
@@ -83,7 +94,8 @@ fun ChatScreen(
     onChatRoomClick: (Long) -> Unit,
     controlBottomSheet: (BottomSheetType) -> Unit,
     modifier: Modifier = Modifier,
-    chatRoomList: LazyPagingItems<RoomUiModel>
+    chatRoomList: LazyPagingItems<RoomUiModel>,
+    isChatRoomEmpty: Boolean
 ) {
     Scaffold(
         modifier = modifier,
@@ -125,7 +137,8 @@ fun ChatScreen(
             onEmptyScreenButtonClick = onEmptyScreenButtonClick,
             onChatRoomClick = onChatRoomClick,
             modifier = Modifier.padding(paddingValues),
-            chatRoomList = chatRoomList
+            chatRoomList = chatRoomList,
+            isChatRoomEmpty = isChatRoomEmpty
         )
     }
 }
@@ -135,9 +148,10 @@ fun ChatContent(
     onEmptyScreenButtonClick: () -> Unit,
     onChatRoomClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
-    chatRoomList: LazyPagingItems<RoomUiModel>
+    chatRoomList: LazyPagingItems<RoomUiModel>,
+    isChatRoomEmpty: Boolean
 ) {
-    if (chatRoomList.itemCount == 0) {
+    if (isChatRoomEmpty) {
         EmptyChatScreen(
             onButtonClick = onEmptyScreenButtonClick,
             modifier = modifier.fillMaxSize(),

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
@@ -50,12 +50,11 @@ fun NavGraphBuilder.chatRoomGraph(
             route = KeyLinkNavigationRoute.ChatRoomGraph.ChatRoomDetailRoute.route,
             arguments = listOf(
                 navArgument("roomId") {
-                    type = NavType.StringType
+                    type = NavType.LongType
                 }
             )
         ) { entry ->
             ChatDetailRoute(
-                roomId = entry.arguments?.getString("roomId")?.toLong() ?: -1,
                 onBackClick = onBackClick,
                 onMessageClick = navController::navigateToChatDetail,
                 onReportClick = navController::navigateToChatReport
@@ -64,33 +63,36 @@ fun NavGraphBuilder.chatRoomGraph(
         composable(route = KeyLinkNavigationRoute.ChatRoomGraph.ChatDetailRoute.route,
             arguments = listOf(
                 navArgument("roomId") {
-                    type = NavType.StringType
+                    type = NavType.LongType
                 },
                 navArgument("chatId") {
-                    type = NavType.StringType
+                    type = NavType.LongType
                 }
             )
         ) { entry ->
             MessageDetailRoute(
-                roomId = entry.arguments?.getString("roomId")?.toLong() ?: -1,
-                chatId = entry.arguments?.getString("chatId")?.toLong() ?: -1,
+                chatId = entry.arguments?.getLong("chatId") ?: -1,
                 onBackClick = onBackClick,
                 onReportMenuClick = navController::navigateToChatReport,
-                onReplyButtonClick = navController::navigateToChatReply
+                onReplyButtonClick = {
+                    val roomId = entry.arguments?.getLong("roomId") ?: -1
+                    navController.navigateToChatReply(roomId)
+                }
             )
         }
         composable(
             route = KeyLinkNavigationRoute.ChatRoomGraph.ChatReplyRoute.route,
             arguments = listOf(
                 navArgument("roomId") {
-                    type = NavType.StringType
+                    type = NavType.LongType
                 }
             )
         ) { entry ->
             ChatReplyRoute(
-                roomId = entry.arguments?.getString("roomId")?.toLong() ?: -1,
                 onClickBack = onBackClick,
-                navigateToChat = { roomId ->
+                navigateToChat = {
+                    val roomId = entry.arguments?.getLong("roomId") ?: -1
+
                     navController.navigateToChatRoomDetail(
                         roomId = roomId,
                         navOptions {

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/ChatDetailViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/ChatDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.mashup.presentation.feature.detail
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mashup.domain.usecase.chat.*
@@ -21,11 +22,13 @@ import javax.inject.Inject
 @HiltViewModel
 class ChatDetailViewModel @Inject constructor(
     private val getChatInfoUseCase: GetChatInfoUseCase,
-    private val getChatsUseCase: GetChatsUseCase,
     private val disconnectRoomUseCase: DisconnectRoomUseCase,
     private val getMessageDetailUseCase: GetMessageDetailUseCase,
-    private val replyUseCase: ReplyUseCase
+    private val replyUseCase: ReplyUseCase,
+    getChatsUseCase: GetChatsUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    val roomId = savedStateHandle.get<Long>("roomId") ?: -1
 
     private val _chatInfoUiState: MutableStateFlow<ChatInfoUiState> =
         MutableStateFlow(ChatInfoUiState.Loading)
@@ -46,12 +49,12 @@ class ChatDetailViewModel @Inject constructor(
         MutableStateFlow(MessageDetailUiState.Loading)
     val messageDetailUiState = _messageDetailUiState.asStateFlow()
 
-    private val _eventFlow: MutableSharedFlow<MessageReplyUiEvent> = MutableSharedFlow<MessageReplyUiEvent>()
+    private val _eventFlow: MutableSharedFlow<MessageReplyUiEvent> = MutableSharedFlow()
     val eventFlow = _eventFlow.asSharedFlow()
 
-    fun getChatInfo(id: Long) {
+    fun getChatInfo() {
         viewModelScope.launch {
-            getChatInfoUseCase.execute(id)
+            getChatInfoUseCase.execute(roomId)
                 .catch {
                     _chatInfoUiState.value = ChatInfoUiState.Failure(it.message)
                 }.collect {
@@ -60,14 +63,13 @@ class ChatDetailViewModel @Inject constructor(
         }
     }
 
-
-    fun disconnectRoom(roomId: Long) {
+    fun disconnectRoom() {
         viewModelScope.launch {
             disconnectRoomUseCase.execute(roomId)
         }
     }
 
-    fun getMessageDetail(roomId: Long, chatId: Long) {
+    fun getMessageDetail(chatId: Long) {
         viewModelScope.launch {
             val param = GetMessageDetailUseCase.MessageDetailParam(
                 roomId = roomId,
@@ -83,7 +85,7 @@ class ChatDetailViewModel @Inject constructor(
         }
     }
 
-    fun reply(roomId: Long, content: String) {
+    fun reply(content: String) {
         val param = ReplyUseCase.Param(
             roomId = roomId,
             content = content

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/chat/compose/ChatDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/chat/compose/ChatDetailScreen.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ChatDetailRoute(
-    roomId: Long,
     onBackClick: () -> Unit,
     onMessageClick: (Long, Long) -> Unit,
     onReportClick: () -> Unit,
@@ -76,10 +75,10 @@ fun ChatDetailRoute(
             modifier = modifier,
             onBackClick = onBackClick,
             onMessageClick = { chatId ->
-                onMessageClick(roomId, chatId)
+                onMessageClick(viewModel.roomId, chatId)
             },
             onReportClick = onReportClick,
-            onDisconnectRoom = { viewModel.disconnectRoom(roomId) },
+            onDisconnectRoom = { viewModel.disconnectRoom() },
             chatInfoUiState = chatInfoUiState,
             pagedChatList = pagedChatList
         )

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/chat/compose/ChatDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/chat/compose/ChatDetailScreen.kt
@@ -60,8 +60,7 @@ fun ChatDetailRoute(
         })
 
     LaunchedEffect(Unit) {
-        launch { viewModel.getChatInfo(roomId) }
-        launch { viewModel.getChats(roomId) }
+        launch { viewModel.getChatInfo() }
     }
     LaunchedEffect(pagedChatList.loadState) {
         if (pagedChatList.loadState.refresh is LoadState.NotLoading)

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/message/compose/MessageDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/message/compose/MessageDetailScreen.kt
@@ -37,16 +37,15 @@ import com.mashup.presentation.ui.theme.White
 fun MessageDetailRoute(
     onBackClick: () -> Unit,
     onReportMenuClick: () -> Unit,
-    onReplyButtonClick: (Long) -> Unit,
+    onReplyButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
-    roomId: Long,
     chatId: Long,
     viewModel: ChatDetailViewModel = hiltViewModel()
 ) {
     val messageDetailUiState by viewModel.messageDetailUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.getMessageDetail(roomId = roomId, chatId = chatId)
+        viewModel.getMessageDetail(chatId = chatId)
     }
 
     MessageDetailScreen(
@@ -54,7 +53,7 @@ fun MessageDetailRoute(
         onBackClick = onBackClick,
         onReportMenuClick = onReportMenuClick,
         onReplyButtonClick = {
-            onReplyButtonClick(roomId)
+            onReplyButtonClick()
         },
         messageDetailUiState = messageDetailUiState
     )

--- a/presentation/src/main/java/com/mashup/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/home/HomeScreen.kt
@@ -48,7 +48,6 @@ fun HomeRoute(
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
     modifier: Modifier = Modifier
 ) {
-
     val pagedReceivedSignal = homeViewModel.receivedSignals.collectAsLazyPagingItems()
     val subscribeKeywordsUiState by homeViewModel.subscribeKeywordsState.collectAsStateWithLifecycle()
     var isRefreshing by remember { mutableStateOf(false) }
@@ -60,6 +59,7 @@ fun HomeRoute(
         })
     val context = LocalContext.current
     var backPressedTime = 0L
+    var isSignalEmpty by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         launch {
@@ -67,8 +67,14 @@ fun HomeRoute(
         }
     }
     LaunchedEffect(pagedReceivedSignal.loadState) {
-        if (pagedReceivedSignal.loadState.refresh is LoadState.NotLoading)
+        if (pagedReceivedSignal.loadState.refresh is LoadState.NotLoading) {
             isRefreshing = false
+            isSignalEmpty = false
+        }
+
+        if (pagedReceivedSignal.loadState.refresh is LoadState.Error) {
+            isSignalEmpty = true
+        }
     }
 
 
@@ -92,11 +98,14 @@ fun HomeRoute(
             onGuideClick = onGuideClick,
             onProfileMenuClick = onProfileMenuClick,
             onReceivedSignalClick = onReceivedSignalClick,
-            onSendSignalButtonClick = onSendSignalButtonClick
+            onSendSignalButtonClick = onSendSignalButtonClick,
+            isSignalEmpty = isSignalEmpty
         )
         PullRefreshIndicator(refreshing = isRefreshing, state = pullRefreshState)
     }
-    if (pagedReceivedSignal.loadState.append == LoadState.Loading) {
+    if (pagedReceivedSignal.loadState.append == LoadState.Loading
+        || pagedReceivedSignal.loadState.refresh == LoadState.Loading
+    ) {
         KeyLinkLoading()
     }
 
@@ -111,6 +120,7 @@ private fun HomeBackgroundScreen(
     onProfileMenuClick: () -> Unit,
     onReceivedSignalClick: (Long) -> Unit,
     onSendSignalButtonClick: () -> Unit,
+    isSignalEmpty: Boolean,
     modifier: Modifier = Modifier
 ) {
     val signalCount = pagedReceivedSignal.itemCount
@@ -124,8 +134,10 @@ private fun HomeBackgroundScreen(
             )
         }
     ) { paddingValues ->
-        Box(modifier = modifier.fillMaxSize().padding(paddingValues)) {
-            HomeBackgroundImage(signalCount = signalCount)
+        Box(modifier = modifier
+            .fillMaxSize()
+            .padding(paddingValues)) {
+            HomeBackgroundImage()
             HomeScreen(
                 modifier = Modifier.padding(paddingValues),
                 subscribeKeywordsUiState = subscribeKeywordsUiState,
@@ -134,7 +146,8 @@ private fun HomeBackgroundScreen(
                 onKeywordContainerClick = onKeywordContainerClick,
                 onGuideClick = onGuideClick,
                 onProfileMenuClick = onProfileMenuClick,
-                onReceivedSignalClick = onReceivedSignalClick
+                onReceivedSignalClick = onReceivedSignalClick,
+                isSignalEmpty = isSignalEmpty
             )
         }
     }
@@ -142,8 +155,6 @@ private fun HomeBackgroundScreen(
 
 @Composable
 fun BoxScope.HomeBackgroundImage(
-    signalCount: Int,
-    modifier: Modifier = Modifier
 ) {
     Image(
         modifier = Modifier.fillMaxSize(),
@@ -151,25 +162,6 @@ fun BoxScope.HomeBackgroundImage(
         contentDescription = stringResource(R.string.login_description_space),
         contentScale = ContentScale.Crop
     )
-    if (signalCount == 0) {
-        Image(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth(),
-            painter = painterResource(R.drawable.img_planet_home_empty),
-            contentDescription = stringResource(R.string.home_planet_background_empty),
-            contentScale = ContentScale.Crop
-        )
-    } else {
-        Image(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth(),
-            painter = painterResource(R.drawable.img_planet_home_default),
-            contentDescription = stringResource(R.string.home_planet_background_default),
-            contentScale = ContentScale.Crop
-        )
-    }
 }
 
 @Composable
@@ -181,7 +173,8 @@ fun BoxScope.HomeScreen(
     onGuideClick: () -> Unit,
     onProfileMenuClick: () -> Unit,
     onReceivedSignalClick: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isSignalEmpty: Boolean
 ) {
     val scrollState = rememberLazyListState()
     val isScrollingUp = scrollState.isScrollingUp()
@@ -205,16 +198,35 @@ fun BoxScope.HomeScreen(
             )
         }
 
-        if (signalCount == 0) {
-            EmptyContent(
-                onGuideClick = onGuideClick
-            )
-        } else {
-            ReceivedSignalCards(
-                receivedSignals = pagedReceivedSignal,
-                scrollState = scrollState,
-                onReceivedSignalClick = onReceivedSignalClick,
-            )
+        Box(modifier = Modifier.fillMaxSize()) {
+
+            if (isSignalEmpty) {
+                Image(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth(),
+                    painter = painterResource(R.drawable.img_planet_home_empty),
+                    contentDescription = stringResource(R.string.home_planet_background_empty),
+                    contentScale = ContentScale.Crop
+                )
+                EmptyContent(
+                    onGuideClick = onGuideClick
+                )
+            } else {
+                Image(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth(),
+                    painter = painterResource(R.drawable.img_planet_home_default),
+                    contentDescription = stringResource(R.string.home_planet_background_default),
+                    contentScale = ContentScale.Crop
+                )
+                ReceivedSignalCards(
+                    receivedSignals = pagedReceivedSignal,
+                    scrollState = scrollState,
+                    onReceivedSignalClick = onReceivedSignalClick,
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/home/HomeScreen.kt
@@ -63,9 +63,6 @@ fun HomeRoute(
 
     LaunchedEffect(Unit) {
         launch {
-            homeViewModel.getReceivedSignal()
-        }
-        launch {
             homeViewModel.getSubscribedKeywords()
         }
     }

--- a/presentation/src/main/java/com/mashup/presentation/feature/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/home/HomeViewModel.kt
@@ -51,7 +51,7 @@ class HomeViewModel @Inject constructor(
     val subscribeKeywordsState = _subscribeKeywordsState.asStateFlow()
 
     private val _eventFlow: MutableSharedFlow<SubscribeKeywordUiEvent> =
-        MutableSharedFlow<SubscribeKeywordUiEvent>()
+        MutableSharedFlow()
     val eventFlow = _eventFlow.asSharedFlow()
 
     fun getSubscribedKeywords() {

--- a/presentation/src/main/java/com/mashup/presentation/feature/reply/chat/ChatReplyScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/reply/chat/ChatReplyScreen.kt
@@ -33,9 +33,8 @@ import com.mashup.presentation.ui.theme.White
 
 @Composable
 fun ChatReplyRoute(
-    roomId: Long,
     onClickBack: () -> Unit,
-    navigateToChat: (Long) -> Unit,
+    navigateToChat: () -> Unit,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ChatDetailViewModel = hiltViewModel()
@@ -46,7 +45,7 @@ fun ChatReplyRoute(
     LaunchedEffect(key1 = event) {
         when (event) {
             is MessageReplyUiEvent.SaveSuccess -> {
-                navigateToChat(roomId)
+                navigateToChat()
             }
             is MessageReplyUiEvent.Failure -> {
 
@@ -60,7 +59,7 @@ fun ChatReplyRoute(
         modifier = modifier,
         onReplyTextChange = { reply = it },
         onClickBack = onClickBack,
-        onSendClick = { viewModel.reply(roomId, reply) },
+        onSendClick = { viewModel.reply(reply) },
         onShowSnackbar = onShowSnackbar,
     )
 }
@@ -128,7 +127,6 @@ private fun ChatReplyScreen(
 private fun ReplyScreenPreview() {
     SsamDTheme {
         ChatReplyRoute(
-            roomId = 1,
             onClickBack = {},
             navigateToChat = {},
             onShowSnackbar = { _, _ -> }


### PR DESCRIPTION
## 작업 내역

- 화면 디테일 다녀왔다가 다시 돌아왔을 때 스크롤 잃어버리는 이슈 / 네비게이션이나 화면 전환 시 뷰모델에 캐싱되어있음에도 불구하고 깜빡이는 이슈 -> LaunchedEffect에서 호출하지않도록 변경
- 초기 EmptyState때문에 빈화면 디자인 깜빡였던 이슈 -> api에서 빈 시그널 / 채팅으로 내려왔을 때 PageLoadState에 Error로 던져서 처리

## To. Reviewer

- none


## 화면
| 기능     | 화면     |
|--------|--------|
| 시그널없을때 |https://github.com/mash-up-kr/ssam-d-Android/assets/37477660/9d3de6bb-8531-456a-951d-a10a97679b90|
| 시그널있을때 |https://github.com/mash-up-kr/ssam-d-Android/assets/37477660/8067274f-df19-4c90-90c5-a99ad7c3ac50|





## 관련 이슈
close #259 
close #226 
close #221 

