### PR TITLE
#257 연결됨 툴바 물음표 아이콘 추가 + 클릭 시 바텀시트

### DIFF
--- a/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
+++ b/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
@@ -1,46 +1,91 @@
 package com.mashup.presentation
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
-import androidx.compose.runtime.Composable
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import com.mashup.presentation.navigation.KeyLinkNavHost
-import com.mashup.presentation.ui.common.KeyLinkBottomBar
-import com.mashup.presentation.ui.common.KeyLinkSnackBar
+import com.mashup.presentation.ui.common.*
 import com.mashup.presentation.ui.theme.Black
+import kotlinx.coroutines.launch
 
 /**
  * Ssam_D_Android
  * @author jaesung
  * @created 2023/07/04
  */
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun KeyLinkApp(
     appState: KeyLinkAppState = rememberKeyLinkAppState()
 ) {
-    Scaffold(
-        bottomBar = {
-            if (appState.isBottomBarVisible()) {
-                KeyLinkBottomBar(
-                    destinations = appState.topLevelDestinations,
-                    onNavigateToDestination = appState::navigateToTopLevelDestination,
-                    currentDestination = appState.currentDestination,
+    val coroutineScope = rememberCoroutineScope()
+    var currentBottomSheetType by remember { mutableStateOf(BottomSheetType.CHAT_CONNECTED) }
+
+    KeyLinkBottomSheetLayout(
+        bottomSheetContent = {
+            when (currentBottomSheetType) {
+                BottomSheetType.CHAT_CONNECTED -> KeyLinkConnectedBottomSheet(
+                    modifier = Modifier.fillMaxWidth()
                 )
+                else -> {}
+//                BottomSheetType.CHAT_DETAIL_KEYWORD -> KeyLinkKeywordBottomSheet(
+//                    modifier = Modifier.fillMaxWidth(),
+//                    matchedKeywords = matchedKeywords
+//                )
+//                BottomSheetType.CHAT_DETAIL_MORE -> KeyLinkChatBottomSheet(
+//                    modifier = Modifier.fillMaxWidth(),
+//                    onDisconnectSignal = {
+//                        coroutineScope.launch {
+//                            appState.modalBottomSheetState.hide()
+//                        }
+//                        showDisconnectDialog = true
+//                    },
+//                    onReportUser = { onReportClick() }
+//                )
             }
         },
-        backgroundColor = Black,
-        snackbarHost = { KeyLinkSnackBar(snackBarHostState = appState.scaffoldState.snackbarHostState) },
-        scaffoldState = appState.scaffoldState
-    ) { innerPadding ->
-        KeyLinkNavHost(
-            appState = appState,
-            modifier = Modifier.padding(innerPadding),
-            onShowSnackbar = { message, duration ->
-                appState.showSnackbar(
-                    message = message,
-                    duration = duration
-                )
-            }
-        )
+        modalSheetState = appState.modalBottomSheetState
+    ) {
+        Scaffold(
+            bottomBar = {
+                if (appState.isBottomBarVisible()) {
+                    KeyLinkBottomBar(
+                        destinations = appState.topLevelDestinations,
+                        onNavigateToDestination = appState::navigateToTopLevelDestination,
+                        currentDestination = appState.currentDestination,
+                    )
+                }
+            },
+            backgroundColor = Black,
+            snackbarHost = { KeyLinkSnackBar(snackBarHostState = appState.scaffoldState.snackbarHostState) },
+            scaffoldState = appState.scaffoldState
+        ) { innerPadding ->
+            KeyLinkNavHost(
+                appState = appState,
+                modifier = Modifier.padding(innerPadding),
+                onShowSnackbar = { message, duration ->
+                    appState.showSnackbar(
+                        message = message,
+                        duration = duration
+                    )
+                },
+                controlBottomSheet = { bottomSheetType ->
+                    currentBottomSheetType = bottomSheetType
+                    appState.controlBottomSheet()
+                },
+                onBackClick = {
+                    coroutineScope.launch {
+                        if (appState.modalBottomSheetState.isVisible) appState.modalBottomSheetState.hide()
+                        else appState.navController.navigateUp()
+                    }
+                }
+            )
+        }
     }
+}
+
+enum class BottomSheetType {
+    CHAT_CONNECTED, CHAT_DETAIL_KEYWORD, CHAT_DETAIL_MORE
 }

--- a/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
+++ b/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import com.mashup.presentation.feature.report.navigation.navigateToChatReport
 import com.mashup.presentation.navigation.KeyLinkNavHost
 import com.mashup.presentation.ui.common.*
 import com.mashup.presentation.ui.theme.Black
@@ -23,7 +22,6 @@ fun KeyLinkApp(
 ) {
     val coroutineScope = rememberCoroutineScope()
     var currentBottomSheetType by remember { mutableStateOf(BottomSheetType.CHAT_CONNECTED) }
-    var currentBottomSheetStringList by remember { mutableStateOf(mutableListOf<String>()) }
 
     KeyLinkBottomSheetLayout(
         bottomSheetContent = {
@@ -31,25 +29,7 @@ fun KeyLinkApp(
                 BottomSheetType.CHAT_CONNECTED -> KeyLinkConnectedBottomSheet(
                     modifier = Modifier.fillMaxWidth()
                 )
-                BottomSheetType.CHAT_DETAIL_KEYWORD -> KeyLinkKeywordBottomSheet(
-                    modifier = Modifier.fillMaxWidth(),
-                    matchedKeywords = currentBottomSheetStringList
-                )
-                BottomSheetType.CHAT_DETAIL_MORE -> KeyLinkChatBottomSheet(
-                    modifier = Modifier.fillMaxWidth(),
-                    onDisconnectSignal = {
-                        coroutineScope.launch {
-                            appState.modalBottomSheetState.hide()
-                        }
-                        // showDisconnectDialog = true
-                    },
-                    onReportUser = {
-                        coroutineScope.launch {
-                            appState.modalBottomSheetState.hide()
-                            appState.navController.navigateToChatReport()
-                        }
-                    }
-                )
+                else -> {}
             }
         },
         modalSheetState = appState.modalBottomSheetState
@@ -77,9 +57,8 @@ fun KeyLinkApp(
                         duration = duration
                     )
                 },
-                controlBottomSheet = { bottomSheetType, stringList ->
+                controlBottomSheet = { bottomSheetType ->
                     currentBottomSheetType = bottomSheetType
-                    stringList?.let { currentBottomSheetStringList = it.toMutableList() }
                     appState.controlBottomSheet()
                 },
                 onBackClick = {
@@ -94,5 +73,5 @@ fun KeyLinkApp(
 }
 
 enum class BottomSheetType {
-    CHAT_CONNECTED, CHAT_DETAIL_KEYWORD, CHAT_DETAIL_MORE
+    CHAT_CONNECTED
 }

--- a/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
+++ b/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
@@ -22,6 +22,7 @@ fun KeyLinkApp(
 ) {
     val coroutineScope = rememberCoroutineScope()
     var currentBottomSheetType by remember { mutableStateOf(BottomSheetType.CHAT_CONNECTED) }
+    var currentBottomSheetStringList by remember { mutableStateOf(mutableListOf<String>()) }
 
     KeyLinkBottomSheetLayout(
         bottomSheetContent = {
@@ -29,11 +30,11 @@ fun KeyLinkApp(
                 BottomSheetType.CHAT_CONNECTED -> KeyLinkConnectedBottomSheet(
                     modifier = Modifier.fillMaxWidth()
                 )
+                BottomSheetType.CHAT_DETAIL_KEYWORD -> KeyLinkKeywordBottomSheet(
+                    modifier = Modifier.fillMaxWidth(),
+                    matchedKeywords = currentBottomSheetStringList
+                )
                 else -> {}
-//                BottomSheetType.CHAT_DETAIL_KEYWORD -> KeyLinkKeywordBottomSheet(
-//                    modifier = Modifier.fillMaxWidth(),
-//                    matchedKeywords = matchedKeywords
-//                )
 //                BottomSheetType.CHAT_DETAIL_MORE -> KeyLinkChatBottomSheet(
 //                    modifier = Modifier.fillMaxWidth(),
 //                    onDisconnectSignal = {
@@ -71,8 +72,9 @@ fun KeyLinkApp(
                         duration = duration
                     )
                 },
-                controlBottomSheet = { bottomSheetType ->
+                controlBottomSheet = { bottomSheetType, stringList ->
                     currentBottomSheetType = bottomSheetType
+                    stringList?.let { currentBottomSheetStringList = it.toMutableList() }
                     appState.controlBottomSheet()
                 },
                 onBackClick = {

--- a/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
+++ b/presentation/src/main/java/com/mashup/presentation/KeyLinkApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import com.mashup.presentation.feature.report.navigation.navigateToChatReport
 import com.mashup.presentation.navigation.KeyLinkNavHost
 import com.mashup.presentation.ui.common.*
 import com.mashup.presentation.ui.theme.Black
@@ -34,17 +35,21 @@ fun KeyLinkApp(
                     modifier = Modifier.fillMaxWidth(),
                     matchedKeywords = currentBottomSheetStringList
                 )
-                else -> {}
-//                BottomSheetType.CHAT_DETAIL_MORE -> KeyLinkChatBottomSheet(
-//                    modifier = Modifier.fillMaxWidth(),
-//                    onDisconnectSignal = {
-//                        coroutineScope.launch {
-//                            appState.modalBottomSheetState.hide()
-//                        }
-//                        showDisconnectDialog = true
-//                    },
-//                    onReportUser = { onReportClick() }
-//                )
+                BottomSheetType.CHAT_DETAIL_MORE -> KeyLinkChatBottomSheet(
+                    modifier = Modifier.fillMaxWidth(),
+                    onDisconnectSignal = {
+                        coroutineScope.launch {
+                            appState.modalBottomSheetState.hide()
+                        }
+                        // showDisconnectDialog = true
+                    },
+                    onReportUser = {
+                        coroutineScope.launch {
+                            appState.modalBottomSheetState.hide()
+                            appState.navController.navigateToChatReport()
+                        }
+                    }
+                )
             }
         },
         modalSheetState = appState.modalBottomSheetState

--- a/presentation/src/main/java/com/mashup/presentation/KeyLinkAppState.kt
+++ b/presentation/src/main/java/com/mashup/presentation/KeyLinkAppState.kt
@@ -1,13 +1,7 @@
 package com.mashup.presentation
 
-import androidx.compose.material.ScaffoldState
-import androidx.compose.material.SnackbarDuration
-import androidx.compose.material.SnackbarHostState
-import androidx.compose.material.rememberScaffoldState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -28,18 +22,26 @@ import kotlinx.coroutines.launch
  * @created 2023/07/04
  */
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun rememberKeyLinkAppState(
     navController: NavHostController = rememberNavController(),
     scaffoldState: ScaffoldState = rememberScaffoldState(
         snackbarHostState = remember { SnackbarHostState() }
     ),
+    modalBottomSheetState: ModalBottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        animationSpec = SwipeableDefaults.AnimationSpec,
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = false
+    ),
     coroutineScope: CoroutineScope = rememberCoroutineScope()
 ): KeyLinkAppState {
-    return remember(navController, scaffoldState, coroutineScope) {
+    return remember(navController, scaffoldState, modalBottomSheetState, coroutineScope) {
         KeyLinkAppState(
             navController,
             scaffoldState,
+            modalBottomSheetState,
             coroutineScope
         )
     }
@@ -54,9 +56,10 @@ fun rememberKeyLinkAppState(
  * 5. ...
  */
 @Stable
-class KeyLinkAppState(
+class KeyLinkAppState @OptIn(ExperimentalMaterialApi::class) constructor(
     val navController: NavHostController,
     val scaffoldState: ScaffoldState,
+    val modalBottomSheetState: ModalBottomSheetState,
     val coroutineScope: CoroutineScope
 ) {
     val currentDestination: NavDestination?
@@ -72,6 +75,15 @@ class KeyLinkAppState(
             )
         }
     }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    fun controlBottomSheet() {
+        coroutineScope.launch {
+            if (modalBottomSheetState.isVisible) modalBottomSheetState.hide()
+            else modalBottomSheetState.show()
+        }
+    }
+
     @Composable
     fun isBottomBarVisible(): Boolean {
         return when (currentDestination?.route) {

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
@@ -36,7 +36,7 @@ fun ChatRoute(
     onBackClick: () -> Unit,
     onEmptyScreenButtonClick: () -> Unit,
     onChatRoomClick: (Long) -> Unit,
-    controlBottomSheet: (BottomSheetType) -> Unit,
+    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ChatViewModel = hiltViewModel()
 ) {
@@ -84,7 +84,7 @@ fun ChatRoute(
 fun ChatScreen(
     onEmptyScreenButtonClick: () -> Unit,
     onChatRoomClick: (Long) -> Unit,
-    controlBottomSheet: (BottomSheetType) -> Unit,
+    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
     modifier: Modifier = Modifier,
     chatRoomList: LazyPagingItems<RoomUiModel>
 ) {
@@ -97,7 +97,7 @@ fun ChatScreen(
                     modifier = Modifier
                         .padding(start = 20.dp, top = 24.dp, bottom = 8.dp)
                         .clickable {
-                            controlBottomSheet(BottomSheetType.CHAT_CONNECTED)
+                            controlBottomSheet(BottomSheetType.CHAT_CONNECTED, emptyList())
                         },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -155,19 +155,3 @@ fun ChatContent(
         )
     }
 }
-
-//@Preview(showBackground = true)
-//@Composable
-//private fun ChatScreenPreview() {
-//    val viewModel: ChatViewModel = hiltViewModel()
-//    val pagedChatRoomList = viewModel.pagingData.collectAsLazyPagingItems()
-//
-//    SsamDTheme(darkTheme = true) {
-//        ChatScreen(
-//            onEmptyScreenButtonClick = {},
-//            onChatRoomClick = {},
-//            chatRoomList = pagedChatRoomList
-//        )
-//    }
-//}
-

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
@@ -21,8 +21,11 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.mashup.presentation.R
 import com.mashup.presentation.feature.chat.ChatViewModel
 import com.mashup.presentation.feature.chat.model.RoomUiModel
+import com.mashup.presentation.ui.common.KeyLinkBottomSheetLayout
+import com.mashup.presentation.ui.common.KeyLinkConnectedBottomSheet
 import com.mashup.presentation.ui.common.KeyLinkLoading
 import com.mashup.presentation.ui.theme.*
+import kotlinx.coroutines.launch
 
 /**
  * Ssam_D_Android
@@ -70,6 +73,7 @@ fun ChatRoute(
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ChatScreen(
     onEmptyScreenButtonClick: () -> Unit,
@@ -77,47 +81,67 @@ fun ChatScreen(
     modifier: Modifier = Modifier,
     chatRoomList: LazyPagingItems<RoomUiModel>
 ) {
-    Scaffold(
-        modifier = modifier,
-        backgroundColor = Black,
-        topBar = {
-            Column {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 20.dp, top = 24.dp, bottom = 8.dp)
-                        .clickable {},
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stringResource(R.string.toolbar_chat),
-                        style = Heading3,
-                        color = White
-                    )
+    val coroutineScope = rememberCoroutineScope()
+    val connectedBottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        animationSpec = SwipeableDefaults.AnimationSpec,
+        confirmValueChange = { it != ModalBottomSheetValue.HalfExpanded },
+        skipHalfExpanded = false
+    )
 
-                    Icon(
-                        modifier = Modifier.size(24.dp).padding(start = 6.dp),
-                        painter = painterResource(id = R.drawable.ic_chat_help_24),
-                        contentDescription = "",
-                        tint = Gray08
+    KeyLinkBottomSheetLayout(
+        bottomSheetContent = {
+            KeyLinkConnectedBottomSheet(
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        modalSheetState = connectedBottomSheetState
+    ) {
+        Scaffold(
+            modifier = modifier,
+            backgroundColor = Black,
+            topBar = {
+                Column {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 20.dp, top = 24.dp, bottom = 8.dp)
+                            .clickable {
+                                coroutineScope.launch {
+                                    if (connectedBottomSheetState.isVisible) connectedBottomSheetState.hide()
+                                    else connectedBottomSheetState.show()
+                                }
+                            },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.toolbar_chat),
+                            style = Heading3,
+                            color = White
+                        )
+                        Icon(
+                            modifier = Modifier.size(24.dp).padding(start = 6.dp),
+                            painter = painterResource(id = R.drawable.ic_chat_help_24),
+                            contentDescription = "",
+                            tint = Gray08
+                        )
+                    }
+                    Divider(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Gray03),
+                        thickness = 1.dp
                     )
                 }
-
-                Divider(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(Gray03),
-                    thickness = 1.dp
-                )
             }
+        ) { paddingValues ->
+            ChatContent(
+                onEmptyScreenButtonClick = onEmptyScreenButtonClick,
+                onChatRoomClick = onChatRoomClick,
+                modifier = Modifier.padding(paddingValues),
+                chatRoomList = chatRoomList
+            )
         }
-    ) { paddingValues ->
-        ChatContent(
-            onEmptyScreenButtonClick = onEmptyScreenButtonClick,
-            onChatRoomClick = onChatRoomClick,
-            modifier = Modifier.padding(paddingValues),
-            chatRoomList = chatRoomList
-        )
     }
 }
 

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
@@ -36,7 +36,7 @@ fun ChatRoute(
     onBackClick: () -> Unit,
     onEmptyScreenButtonClick: () -> Unit,
     onChatRoomClick: (Long) -> Unit,
-    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
+    controlBottomSheet: (BottomSheetType) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ChatViewModel = hiltViewModel()
 ) {
@@ -84,7 +84,7 @@ fun ChatRoute(
 fun ChatScreen(
     onEmptyScreenButtonClick: () -> Unit,
     onChatRoomClick: (Long) -> Unit,
-    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
+    controlBottomSheet: (BottomSheetType) -> Unit,
     modifier: Modifier = Modifier,
     chatRoomList: LazyPagingItems<RoomUiModel>
 ) {
@@ -97,7 +97,7 @@ fun ChatScreen(
                     modifier = Modifier
                         .padding(start = 20.dp, top = 24.dp, bottom = 8.dp)
                         .clickable {
-                            controlBottomSheet(BottomSheetType.CHAT_CONNECTED, emptyList())
+                            controlBottomSheet(BottomSheetType.CHAT_CONNECTED)
                         },
                     verticalAlignment = Alignment.CenterVertically
                 ) {

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/compose/ChatScreen.kt
@@ -1,17 +1,16 @@
 package com.mashup.presentation.feature.chat.compose
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Divider
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -83,14 +82,26 @@ fun ChatScreen(
         backgroundColor = Black,
         topBar = {
             Column {
-                Text(
-                    text = stringResource(R.string.toolbar_chat),
-                    style = Heading3,
-                    color = White,
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 20.dp, top = 24.dp, bottom = 8.dp)
-                )
+                        .clickable {},
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.toolbar_chat),
+                        style = Heading3,
+                        color = White
+                    )
+
+                    Icon(
+                        modifier = Modifier.size(24.dp).padding(start = 6.dp),
+                        painter = painterResource(id = R.drawable.ic_chat_help_24),
+                        contentDescription = "",
+                        tint = Gray08
+                    )
+                }
 
                 Divider(
                     modifier = Modifier

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
@@ -32,7 +32,7 @@ fun NavGraphBuilder.chatRoomGraph(
     navController: NavController,
     onBackClick: () -> Unit,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
-    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit
+    controlBottomSheet: (BottomSheetType) -> Unit
 ) {
     navigation(
         route = KeyLinkNavigationRoute.ChatRoomGraph.route,
@@ -58,7 +58,7 @@ fun NavGraphBuilder.chatRoomGraph(
                 roomId = entry.arguments?.getString("roomId")?.toLong() ?: -1,
                 onBackClick = onBackClick,
                 onMessageClick = navController::navigateToChatDetail,
-                controlBottomSheet = controlBottomSheet
+                onReportClick = navController::navigateToChatReport
             )
         }
         composable(route = KeyLinkNavigationRoute.ChatRoomGraph.ChatDetailRoute.route,

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
@@ -3,6 +3,7 @@ package com.mashup.presentation.feature.chat.navigation
 import androidx.compose.material.SnackbarDuration
 import androidx.navigation.*
 import androidx.navigation.compose.composable
+import com.mashup.presentation.BottomSheetType
 import com.mashup.presentation.feature.chat.compose.ChatRoute
 import com.mashup.presentation.feature.detail.chat.compose.ChatDetailRoute
 import com.mashup.presentation.feature.detail.chat.navigation.navigateToChatRoomDetail
@@ -31,6 +32,7 @@ fun NavGraphBuilder.chatRoomGraph(
     navController: NavController,
     onBackClick: () -> Unit,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
+    controlBottomSheet: (BottomSheetType) -> Unit
 ) {
     navigation(
         route = KeyLinkNavigationRoute.ChatRoomGraph.route,
@@ -38,8 +40,10 @@ fun NavGraphBuilder.chatRoomGraph(
     ) {
         composable(route = KeyLinkNavigationRoute.ChatRoomGraph.ChatRoomRoute.route) {
             ChatRoute(
+                onBackClick = onBackClick,
                 onEmptyScreenButtonClick = navController::navigateToSignal,
-                onChatRoomClick = navController::navigateToChatRoomDetail
+                onChatRoomClick = navController::navigateToChatRoomDetail,
+                controlBottomSheet = controlBottomSheet
             )
         }
         composable(

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
@@ -32,7 +32,7 @@ fun NavGraphBuilder.chatRoomGraph(
     navController: NavController,
     onBackClick: () -> Unit,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
-    controlBottomSheet: (BottomSheetType) -> Unit
+    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit
 ) {
     navigation(
         route = KeyLinkNavigationRoute.ChatRoomGraph.route,
@@ -58,7 +58,8 @@ fun NavGraphBuilder.chatRoomGraph(
                 roomId = entry.arguments?.getString("roomId")?.toLong() ?: -1,
                 onBackClick = onBackClick,
                 onMessageClick = navController::navigateToChatDetail,
-                onReportClick = navController::navigateToChatReport
+                onReportClick = navController::navigateToChatReport,
+                controlBottomSheet = controlBottomSheet
             )
         }
         composable(route = KeyLinkNavigationRoute.ChatRoomGraph.ChatDetailRoute.route,

--- a/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/chat/navigation/ChatNavigation.kt
@@ -58,7 +58,6 @@ fun NavGraphBuilder.chatRoomGraph(
                 roomId = entry.arguments?.getString("roomId")?.toLong() ?: -1,
                 onBackClick = onBackClick,
                 onMessageClick = navController::navigateToChatDetail,
-                onReportClick = navController::navigateToChatReport,
                 controlBottomSheet = controlBottomSheet
             )
         }

--- a/presentation/src/main/java/com/mashup/presentation/feature/detail/chat/compose/ChatDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/detail/chat/compose/ChatDetailScreen.kt
@@ -45,7 +45,6 @@ fun ChatDetailRoute(
     roomId: Long,
     onBackClick: () -> Unit,
     onMessageClick: (Long, Long) -> Unit,
-    onReportClick: () -> Unit,
     controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ChatDetailViewModel = hiltViewModel()
@@ -84,7 +83,6 @@ fun ChatDetailRoute(
             onMessageClick = { chatId ->
                 onMessageClick(roomId, chatId)
             },
-            onReportClick = onReportClick,
             onDisconnectRoom = { viewModel.disconnectRoom(roomId) },
             controlBottomSheet = controlBottomSheet,
             chatInfoUiState = chatInfoUiState,
@@ -102,7 +100,6 @@ private fun ChatDetailScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
     onMessageClick: (Long) -> Unit,
-    onReportClick: () -> Unit,
     onDisconnectRoom: () -> Unit,
     controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
     chatInfoUiState: ChatInfoUiState,

--- a/presentation/src/main/java/com/mashup/presentation/navigation/KeyLinkNavHost.kt
+++ b/presentation/src/main/java/com/mashup/presentation/navigation/KeyLinkNavHost.kt
@@ -21,7 +21,7 @@ import com.mashup.presentation.feature.signal.send.navigation.signalGraph
 fun KeyLinkNavHost(
     appState: KeyLinkAppState,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
-    controlBottomSheet: (BottomSheetType) -> Unit,
+    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     startDestination: String = KeyLinkNavigationRoute.HomeGraph.route

--- a/presentation/src/main/java/com/mashup/presentation/navigation/KeyLinkNavHost.kt
+++ b/presentation/src/main/java/com/mashup/presentation/navigation/KeyLinkNavHost.kt
@@ -21,7 +21,7 @@ import com.mashup.presentation.feature.signal.send.navigation.signalGraph
 fun KeyLinkNavHost(
     appState: KeyLinkAppState,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
-    controlBottomSheet: (BottomSheetType, List<String>?) -> Unit,
+    controlBottomSheet: (BottomSheetType) -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     startDestination: String = KeyLinkNavigationRoute.HomeGraph.route

--- a/presentation/src/main/java/com/mashup/presentation/navigation/KeyLinkNavHost.kt
+++ b/presentation/src/main/java/com/mashup/presentation/navigation/KeyLinkNavHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.SnackbarDuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import com.mashup.presentation.BottomSheetType
 import com.mashup.presentation.KeyLinkAppState
 import com.mashup.presentation.feature.chat.navigation.chatRoomGraph
 import com.mashup.presentation.feature.detail.message.navigation.receivedSignalGraph
@@ -20,6 +21,8 @@ import com.mashup.presentation.feature.signal.send.navigation.signalGraph
 fun KeyLinkNavHost(
     appState: KeyLinkAppState,
     onShowSnackbar: (String, SnackbarDuration) -> Unit,
+    controlBottomSheet: (BottomSheetType) -> Unit,
+    onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     startDestination: String = KeyLinkNavigationRoute.HomeGraph.route
 ) {
@@ -40,8 +43,9 @@ fun KeyLinkNavHost(
         )
         chatRoomGraph(
             navController = navController,
-            onBackClick = navController::navigateUp,
-            onShowSnackbar = onShowSnackbar
+            onBackClick = onBackClick,
+            onShowSnackbar = onShowSnackbar,
+            controlBottomSheet = controlBottomSheet
         )
         profileGraph(
             navController = navController,

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkBottomSheet.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkBottomSheet.kt
@@ -62,7 +62,8 @@ fun KeyLinkChatBottomSheetItem(
 ) {
     Row(
         modifier = modifier
-            .clickable { onAction() }.padding(vertical = 16.dp),
+            .clickable { onAction() }
+            .padding(vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
@@ -105,6 +106,27 @@ fun KeyLinkKeywordBottomSheet(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun KeyLinkConnectedBottomSheet(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 20.dp),
+    ) {
+        Text(
+            modifier = Modifier.padding(bottom = 12.dp),
+            text = stringResource(R.string.bottom_sheet_connected_title),
+            style = Title2,
+            color = Gray10
+        )
+        Text(
+            text = stringResource(R.string.bottom_sheet_connected_content),
+            style = Body2,
+            color = Gray10
+        )
     }
 }
 

--- a/presentation/src/main/res/drawable/ic_chat_help_24.xml
+++ b/presentation/src/main/res/drawable/ic_chat_help_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11,18h2v-2h-2v2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM12,6c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2c0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4z"/>
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -137,4 +137,6 @@
 
     // 채팅
     <string name="chat_room_disconnect_room_guide">상대방이 연결을 끊었습니다.\n더이상 대화를 할 수 없습니다.</string>
+    <string name="bottom_sheet_connected_title">연결 기준이 뭔가요?</string>
+    <string name="bottom_sheet_connected_content">1. 내가 보낸 시그널에 상대가 답신하면 연결돼요.\n2. 구독중인 키워드에 상대의 시그널이 도착하고, 내가 그 시그널에 답신하면 연결돼요. </string>
 </resources>


### PR DESCRIPTION
## 작업 내역

- 연결됨 툴바 물음표 아이콘 추가 + 클릭 시 바텀시트 세팅
- 바텀시트 visible 상태에서 백키 클릭 시 내려가게끔 세팅

## To. Reviewer

- 모든 바텀시트를 KeyLinkApp으로 옮기려 했으나.. ChatDetailScreen에서 사용하는 바텀 시트의 경우 파라미터로 리스트를 넘겨줘야 하고 클릭 시 이벤트가 있어서 옮겼다가 다시 원복했슴다 파라미터 리스트 넘겨주는 건 괜찮은데 이벤트 받은 후에 다시 값을 내려주는 게 안돼서 원복했어요

## 화면
| 기능     | 화면     |
|--------|--------|
| 바텀시트 | 

https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/c6f29f41-01db-4e3f-9b5b-c96e89eee16f


## 관련 이슈
close #257 
