### PR TITLE
#170 #254 FCM 작업

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,9 +45,10 @@ jobs:
 
       # google-services 생성
       - name: Generate google_services.json from Github Secrets
-        run: echo "$GOOGLE_SERVICES" > ./app/google-services.json
+        run: |
+          echo "$GOOGLE_SERVICES" | base64 -d -i > ./app/google-services.json
         env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG }}
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG_BASE64 }}
 
       # Keystore 파일 생성
       - name: Generate Keystore file from Github Secrets

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,8 +45,7 @@ jobs:
 
       # google-services 생성
       - name: Generate google_services.json from Github Secrets
-        run: |
-          echo "$GOOGLE_SERVICES" > ./app/src/debug/google-services.json
+        run: echo "$GOOGLE_SERVICES" > ./app/google-services.json
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG }}
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,19 +43,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # google-services 생성
-      - name: Generate google_services.json from Github Secrets
-        run: echo "$GOOGLE_SERVICES" > ./app/src/debug/google-services.json
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG }}
-
-#      # google-services 생성
-#      - name: Generate google_services.json from Github Secrets
-#        run: |
-#          echo "$GOOGLE_SERVICES" | base64 -d -i > ./app/google-services.json
-#        env:
-#          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG_BASE64 }}
-
       # Keystore 파일 생성
       - name: Generate Keystore file from Github Secrets
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # google-services 생성
+      - name: Generate google_services.json from Github Secrets
+        run: |
+          echo "$GOOGLE_SERVICES" > ./app/src/debug/google-services.json
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG }}
+
       # Keystore 파일 생성
       - name: Generate Keystore file from Github Secrets
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,7 +45,7 @@ jobs:
 
       # google-services 생성
       - name: Generate google_services.json from Github Secrets
-        run: echo "$GOOGLE_SERVICES" > ./app/google-services.json
+        run: echo "$GOOGLE_SERVICES" > ./app/src/debug/google-services.json
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG }}
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,10 +45,16 @@ jobs:
 
       # google-services 생성
       - name: Generate google_services.json from Github Secrets
-        run: |
-          echo "$GOOGLE_SERVICES" | base64 -d -i > ./app/google-services.json
+        run: echo "$GOOGLE_SERVICES" > ./app/google-services.json
         env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG_BASE64 }}
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG }}
+
+#      # google-services 생성
+#      - name: Generate google_services.json from Github Secrets
+#        run: |
+#          echo "$GOOGLE_SERVICES" | base64 -d -i > ./app/google-services.json
+#        env:
+#          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_DEBUG_BASE64 }}
 
       # Keystore 파일 생성
       - name: Generate Keystore file from Github Secrets

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ render.experimental.xml
 *.keystore
 
 # Google Services (e.g. APIs or Firebase)
-google-services.json
+#google-services.json
 
 # Android Profiling
 *.hprof

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'com.google.dagger.hilt.android'
+    id 'com.google.gms.google-services'
 }
 
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -95,4 +96,8 @@ dependencies {
 
     // kakao login
     implementation Dep.Kakao.sdk
+
+    // firebase
+    implementation platform(Dep.Firebase.firebaseBom)
+    implementation Dep.Firebase.cloudMessaging
 }

--- a/app/src/debug/google-services.json
+++ b/app/src/debug/google-services.json
@@ -1,0 +1,76 @@
+{
+  "project_info": {
+    "project_number": "832727038255",
+    "project_id": "keylink-731df",
+    "storage_bucket": "keylink-731df.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:832727038255:android:2a36823f5b6835c29d09da",
+        "android_client_info": {
+          "package_name": "com.mashup.ssamd"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "832727038255-789jestndq3tqhosf2rj0lodgv06ii23.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.mashup.ssamd",
+            "certificate_hash": "1519448b6407650d0d0e6d3fe0c2cb361ddeef68"
+          }
+        },
+        {
+          "client_id": "832727038255-dmmombtpj0n3rjihgu8nsk3didie2h97.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCYzKRoLm4ZdbAGgIJ9kgGtQQCLed_Q37M"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "832727038255-dmmombtpj0n3rjihgu8nsk3didie2h97.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:832727038255:android:bc5a57ee6437bce19d09da",
+        "android_client_info": {
+          "package_name": "com.mashup.ssamd.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "832727038255-dmmombtpj0n3rjihgu8nsk3didie2h97.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCYzKRoLm4ZdbAGgIJ9kgGtQQCLed_Q37M"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "832727038255-dmmombtpj0n3rjihgu8nsk3didie2h97.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
 
     <application
         android:name=".SsamDApplication"
-        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -16,6 +15,16 @@
         android:label="${appName}"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ssam_D_Android"
-        tools:targetApi="31" />
+        android:usesCleartextTraffic="true"
+        tools:targetApi="31">
+
+        <service
+            android:name=".KeyLinkService"
+            android:exported="false" >
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/mashup/ssamd/KeyLinkService.kt
+++ b/app/src/main/java/com/mashup/ssamd/KeyLinkService.kt
@@ -1,111 +1,30 @@
 package com.mashup.ssamd
 
-import android.Manifest
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Build
 import android.util.Log
-import androidx.core.app.ActivityCompat
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.mashup.presentation.navigation.MainActivity
-import timber.log.Timber
+import com.mashup.ssamd.notification.ShowPushNotificationUseCase
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 /**
  * Ssam_D_Android
  * @author jaesung
  * @created 2023/07/29
  */
+@AndroidEntryPoint
 class KeyLinkService : FirebaseMessagingService() {
+
+    @Inject
+    lateinit var showPushNotificationUseCase: ShowPushNotificationUseCase
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         Log.e("SSSS","Device Token : $token")
     }
 
-    override fun onMessageReceived(message: RemoteMessage) {
-        super.onMessageReceived(message)
-
-
-        val title = message.notification?.title
-        val body = message.notification?.body
-
-        Timber.e("${title}")
-//        message.notification?.imageUrl
-//        val imageUrl = message.notification?.imageUrl
-
-        if (title != null && body != null) {
-            createNotificationChannel()
-            notifyKeyLinkPush(title, body)
-        }
-    }
-
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_HIGH
-            )
-            val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
-        }
-    }
-
-    private fun notifyKeyLinkPush(title: String, body: String) {
-        val intent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
-
-        val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.getActivity(
-                this,
-                PENDING_REQUEST_CODE,
-                intent,
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            )
-        } else {
-            PendingIntent.getActivity(
-                this,
-                PENDING_REQUEST_CODE,
-                intent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            )
-        }
-
-        val notificationBuilder = NotificationCompat.Builder(this, CHANNEL_ID).apply {
-            setSmallIcon(R.mipmap.ic_launcher)  // Icon
-            setWhen(1)  // 시간
-            setContentTitle(title)  // 제목
-            setContentText(body)  // 텍스트
-            priority = NotificationCompat.PRIORITY_HIGH
-            setAutoCancel(false)
-//            setContentIntent(pendingIntent)
-            setFullScreenIntent(pendingIntent, true)
-        }.build()
-
-        if (ActivityCompat.checkSelfPermission(
-                this,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-
-            return
-        }
-        NotificationManagerCompat.from(this).notify(
-            notificationId++,
-            notificationBuilder
-        )
-    }
-
-    companion object {
-        private const val CHANNEL_ID = "KeyLinkNotificationChannel"
-        private const val CHANNEL_NAME = "KeyLink 알림"
-        private const val PENDING_REQUEST_CODE = 1
-        private var notificationId = 1
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        showPushNotificationUseCase.invoke(remoteMessage)
     }
 }

--- a/app/src/main/java/com/mashup/ssamd/KeyLinkService.kt
+++ b/app/src/main/java/com/mashup/ssamd/KeyLinkService.kt
@@ -1,0 +1,111 @@
+package com.mashup.ssamd
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.mashup.presentation.navigation.MainActivity
+import timber.log.Timber
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/29
+ */
+class KeyLinkService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Log.e("SSSS","Device Token : $token")
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+
+
+        val title = message.notification?.title
+        val body = message.notification?.body
+
+        Timber.e("${title}")
+//        message.notification?.imageUrl
+//        val imageUrl = message.notification?.imageUrl
+
+        if (title != null && body != null) {
+            createNotificationChannel()
+            notifyKeyLinkPush(title, body)
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun notifyKeyLinkPush(title: String, body: String) {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+
+        val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.getActivity(
+                this,
+                PENDING_REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+        } else {
+            PendingIntent.getActivity(
+                this,
+                PENDING_REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+        }
+
+        val notificationBuilder = NotificationCompat.Builder(this, CHANNEL_ID).apply {
+            setSmallIcon(R.mipmap.ic_launcher)  // Icon
+            setWhen(1)  // 시간
+            setContentTitle(title)  // 제목
+            setContentText(body)  // 텍스트
+            priority = NotificationCompat.PRIORITY_HIGH
+            setAutoCancel(false)
+//            setContentIntent(pendingIntent)
+            setFullScreenIntent(pendingIntent, true)
+        }.build()
+
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+
+            return
+        }
+        NotificationManagerCompat.from(this).notify(
+            notificationId++,
+            notificationBuilder
+        )
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "KeyLinkNotificationChannel"
+        private const val CHANNEL_NAME = "KeyLink 알림"
+        private const val PENDING_REQUEST_CODE = 1
+        private var notificationId = 1
+    }
+}

--- a/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
@@ -3,7 +3,6 @@ package com.mashup.ssamd.notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
-import android.net.Uri.Builder
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -20,7 +19,7 @@ object NotificationConfigs {
     private const val SIGNAL_CHANNEL_NAME = "구독 키워드 시그널 도착 알림"
     private const val CHAT_NOTIFICATION_ID = 2
     private const val CHAT_CHANNEL_ID = "KeyLinkChat"
-    private const val CHAT_CHANNEL_NAME = "키링 채팅 도착 알림"
+    private const val CHAT_CHANNEL_NAME = "채팅 도착 알림"
 
     fun notifyReceivedSignal(
         context: Context,

--- a/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
@@ -14,10 +14,8 @@ import com.google.firebase.messaging.FirebaseMessagingService
  */
 object NotificationConfigs {
 
-    private const val SIGNAL_NOTIFICATION_ID = 1
     private const val SIGNAL_CHANNEL_ID = "KeyLinkSignal"
     private const val SIGNAL_CHANNEL_NAME = "구독 키워드 시그널 도착 알림"
-    private const val CHAT_NOTIFICATION_ID = 2
     private const val CHAT_CHANNEL_ID = "KeyLinkChat"
     private const val CHAT_CHANNEL_NAME = "채팅 도착 알림"
 

--- a/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
@@ -1,0 +1,81 @@
+package com.mashup.ssamd.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.net.Uri.Builder
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/08/01
+ */
+object NotificationConfigs {
+
+    private const val SIGNAL_NOTIFICATION_ID = 1
+    private const val SIGNAL_CHANNEL_ID = "KeyLinkSignal"
+    private const val SIGNAL_CHANNEL_NAME = "구독 키워드 시그널 도착 알림"
+    private const val CHAT_NOTIFICATION_ID = 2
+    private const val CHAT_CHANNEL_ID = "KeyLinkChat"
+    private const val CHAT_CHANNEL_NAME = "키링 채팅 도착 알림"
+
+    fun notifyReceivedSignal(
+        context: Context,
+        setNotificationAttrs: NotificationCompat.Builder.() -> NotificationCompat.Builder
+    ) {
+        initializeNotificationChannel(context)
+        context.getNotificationManager().run {
+            notify(
+                SIGNAL_NOTIFICATION_ID,
+                NotificationCompat.Builder(
+                    context,
+                    SIGNAL_CHANNEL_ID
+                ).setNotificationAttrs().build()
+            )
+        }
+    }
+
+    fun notifyNewChat(
+        context: Context,
+        setNotificationAttrs: NotificationCompat.Builder.() -> NotificationCompat.Builder
+    ) {
+        initializeNotificationChannel(context)
+        context.getNotificationManager().run {
+            notify(
+                CHAT_NOTIFICATION_ID,
+                NotificationCompat.Builder(
+                    context,
+                    CHAT_CHANNEL_ID
+                ).setNotificationAttrs().build()
+            )
+        }
+    }
+
+    private fun initializeNotificationChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.getNotificationManager().run {
+                val signalChannel = NotificationChannel(
+                    SIGNAL_CHANNEL_ID,
+                    SIGNAL_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+
+                val chatChannel = NotificationChannel(
+                    CHAT_CHANNEL_ID,
+                    CHAT_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+                createNotificationChannels(listOf(signalChannel, chatChannel))
+            }
+
+        }
+    }
+
+    private fun Context.getNotificationManager(): NotificationManager {
+        return getSystemService(FirebaseMessagingService.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+}

--- a/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/NotificationConfigs.kt
@@ -28,7 +28,7 @@ object NotificationConfigs {
         initializeNotificationChannel(context)
         context.getNotificationManager().run {
             notify(
-                SIGNAL_NOTIFICATION_ID,
+                (System.currentTimeMillis()/1000).toInt(),
                 NotificationCompat.Builder(
                     context,
                     SIGNAL_CHANNEL_ID
@@ -44,7 +44,7 @@ object NotificationConfigs {
         initializeNotificationChannel(context)
         context.getNotificationManager().run {
             notify(
-                CHAT_NOTIFICATION_ID,
+                (System.currentTimeMillis()/1000).toInt(),
                 NotificationCompat.Builder(
                     context,
                     CHAT_CHANNEL_ID
@@ -69,7 +69,6 @@ object NotificationConfigs {
                 )
                 createNotificationChannels(listOf(signalChannel, chatChannel))
             }
-
         }
     }
 

--- a/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
@@ -1,7 +1,9 @@
 package com.mashup.ssamd.notification
 
+import android.util.Log
 import com.google.firebase.messaging.RemoteMessage
 import com.mashup.ssamd.notification.builder.NotificationBuilder
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -15,8 +17,29 @@ class ShowPushNotificationUseCase @Inject constructor(
     operator fun invoke(remoteMessage: RemoteMessage) {
         val title = remoteMessage.notification?.title
         val body = remoteMessage.notification?.body
-        if (title != null && body != null) {
-            notificationBuilder.showReceivedSignalNotification(title, body)
+        val notificationType = remoteMessage.data["notiType"]
+        val receivedTimeMillis = remoteMessage.data["receivedTimeMillis"]
+        val roomId = remoteMessage.data["roomId"]
+
+        if (title != null && body != null && notificationType != null && roomId != null && receivedTimeMillis != null) {
+            when (notificationType) {
+                SIGNAL_TYPE -> notificationBuilder.showReceivedSignalNotification(
+                    title,
+                    body,
+                    receivedTimeMillis
+                )
+                CHAT_TYPE -> notificationBuilder.showNewChatNotification(
+                    title,
+                    body,
+                    roomId,
+                    receivedTimeMillis
+                )
+            }
         }
+    }
+
+    companion object {
+        private const val SIGNAL_TYPE = "SIGNAL"
+        private const val CHAT_TYPE = "CHAT"
     }
 }

--- a/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
@@ -13,10 +13,8 @@ class ShowPushNotificationUseCase @Inject constructor(
     private val notificationBuilder: NotificationBuilder
 ) {
     operator fun invoke(remoteMessage: RemoteMessage) {
-        val title = remoteMessage.notification?.title.orEmpty()
-        val body = remoteMessage.notification?.body.orEmpty()
-//        val title = remoteMessage.data["title"]
-//        val body = remoteMessage.data["body"]
+        val title = remoteMessage.data["title"].orEmpty()
+        val body = remoteMessage.data["body"].orEmpty()
         val notificationType = remoteMessage.data["notiType"].orEmpty()
         val roomId = remoteMessage.data["roomId"].orEmpty()
 

--- a/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
@@ -1,9 +1,7 @@
 package com.mashup.ssamd.notification
 
-import android.util.Log
 import com.google.firebase.messaging.RemoteMessage
 import com.mashup.ssamd.notification.builder.NotificationBuilder
-import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -18,22 +16,12 @@ class ShowPushNotificationUseCase @Inject constructor(
         val title = remoteMessage.notification?.title
         val body = remoteMessage.notification?.body
         val notificationType = remoteMessage.data["notiType"]
-        val receivedTimeMillis = remoteMessage.data["receivedTimeMillis"]
         val roomId = remoteMessage.data["roomId"]
 
-        if (title != null && body != null && notificationType != null && roomId != null && receivedTimeMillis != null) {
+        if (title != null && body != null && notificationType != null && roomId != null) {
             when (notificationType) {
-                SIGNAL_TYPE -> notificationBuilder.showReceivedSignalNotification(
-                    title,
-                    body,
-                    receivedTimeMillis
-                )
-                CHAT_TYPE -> notificationBuilder.showNewChatNotification(
-                    title,
-                    body,
-                    roomId,
-                    receivedTimeMillis
-                )
+                SIGNAL_TYPE -> notificationBuilder.showReceivedSignalNotification(title, body)
+                CHAT_TYPE -> notificationBuilder.showNewChatNotification(title, body, roomId)
             }
         }
     }

--- a/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
@@ -13,10 +13,12 @@ class ShowPushNotificationUseCase @Inject constructor(
     private val notificationBuilder: NotificationBuilder
 ) {
     operator fun invoke(remoteMessage: RemoteMessage) {
-        val title = remoteMessage.notification?.title
-        val body = remoteMessage.notification?.body
-        val notificationType = remoteMessage.data["notiType"]
-        val roomId = remoteMessage.data["roomId"]
+        val title = remoteMessage.notification?.title.orEmpty()
+        val body = remoteMessage.notification?.body.orEmpty()
+//        val title = remoteMessage.data["title"]
+//        val body = remoteMessage.data["body"]
+        val notificationType = remoteMessage.data["notiType"].orEmpty()
+        val roomId = remoteMessage.data["roomId"].orEmpty()
 
         if (title != null && body != null && notificationType != null && roomId != null) {
             when (notificationType) {

--- a/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/ShowPushNotificationUseCase.kt
@@ -1,0 +1,22 @@
+package com.mashup.ssamd.notification
+
+import com.google.firebase.messaging.RemoteMessage
+import com.mashup.ssamd.notification.builder.NotificationBuilder
+import javax.inject.Inject
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/08/01
+ */
+class ShowPushNotificationUseCase @Inject constructor(
+    private val notificationBuilder: NotificationBuilder
+) {
+    operator fun invoke(remoteMessage: RemoteMessage) {
+        val title = remoteMessage.notification?.title
+        val body = remoteMessage.notification?.body
+        if (title != null && body != null) {
+            notificationBuilder.showReceivedSignalNotification(title, body)
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilder.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilder.kt
@@ -7,7 +7,7 @@ package com.mashup.ssamd.notification.builder
  */
 interface NotificationBuilder {
 
-    fun showReceivedSignalNotification(title: String, body: String, receivedTimeMillis: String)
+    fun showReceivedSignalNotification(title: String, body: String)
 
-    fun showNewChatNotification(title: String, body: String, roomId: String, receivedTimeMillis: String)
+    fun showNewChatNotification(title: String, body: String, roomId: String)
 }

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilder.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilder.kt
@@ -1,0 +1,13 @@
+package com.mashup.ssamd.notification.builder
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/08/01
+ */
+interface NotificationBuilder {
+
+    fun showReceivedSignalNotification(title: String, body: String)
+
+    fun showNewChatNotification()
+}

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilder.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilder.kt
@@ -7,7 +7,7 @@ package com.mashup.ssamd.notification.builder
  */
 interface NotificationBuilder {
 
-    fun showReceivedSignalNotification(title: String, body: String)
+    fun showReceivedSignalNotification(title: String, body: String, receivedTimeMillis: String)
 
-    fun showNewChatNotification()
+    fun showNewChatNotification(title: String, body: String, roomId: String, receivedTimeMillis: String)
 }

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import com.mashup.presentation.common.extension.getDisplayedTime
 import com.mashup.presentation.navigation.MainActivity
 import com.mashup.ssamd.R
 import com.mashup.ssamd.notification.NotificationConfigs
@@ -20,24 +21,35 @@ class NotificationBuilderImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : NotificationBuilder {
 
-    override fun showReceivedSignalNotification(title: String, body: String) {
+    override fun showReceivedSignalNotification(
+        title: String,
+        body: String,
+        receivedTimeMillis: String
+    ) {
         NotificationConfigs.notifyReceivedSignal(context) {
+            setStyle(NotificationCompat.BigTextStyle().bigText(body))
             setSmallIcon(R.mipmap.ic_launcher)
-            setWhen(1)
-            setContentTitle("title")
-            setContentText("body")
+            setWhen(receivedTimeMillis.toLong())
+            setContentTitle(title)
+            setContentText(body)
             priority = NotificationCompat.PRIORITY_HIGH
             setAutoCancel(true)
             setFullScreenIntent(makeLauncherPendingIntent(), true)
         }
     }
 
-    override fun showNewChatNotification() {
+    override fun showNewChatNotification(
+        title: String,
+        body: String,
+        roomId: String,
+        receivedTimeMillis: String
+    ) {
         NotificationConfigs.notifyNewChat(context) {
+            setStyle(NotificationCompat.BigTextStyle().bigText(body))
             setSmallIcon(R.mipmap.ic_launcher)
-            setWhen(1)
-            setContentTitle("title")
-            setContentText("body")
+            setWhen(receivedTimeMillis.toLong())
+            setContentTitle(title)
+            setContentText(body)
             priority = NotificationCompat.PRIORITY_HIGH
             setAutoCancel(true)
             setFullScreenIntent(makeLauncherPendingIntent(), true)

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
@@ -28,8 +28,9 @@ class NotificationBuilderImpl @Inject constructor(
             setContentText(body)
             priority = NotificationCompat.PRIORITY_HIGH
             setAutoCancel(true)
-            setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
-            setFullScreenIntent(makeLauncherPendingIntent(), true)
+            setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            setContentIntent(makeChatLauncherPendingIntent())
         }
     }
 
@@ -41,8 +42,9 @@ class NotificationBuilderImpl @Inject constructor(
             setContentText(body)
             priority = NotificationCompat.PRIORITY_HIGH
             setAutoCancel(true)
-            setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
-            setFullScreenIntent(makeLauncherPendingIntent(), true)
+            setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            setContentIntent(makeChatLauncherPendingIntent())
         }
     }
 
@@ -52,7 +54,7 @@ class NotificationBuilderImpl @Inject constructor(
         }
     }
 
-    private fun makeLauncherPendingIntent(): PendingIntent {
+    private fun makeChatLauncherPendingIntent(): PendingIntent {
         val intent = createMainIntent()
         val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT
@@ -62,13 +64,30 @@ class NotificationBuilderImpl @Inject constructor(
 
         return PendingIntent.getActivity(
             context,
-            PENDING_REQUEST_CODE,
+            CHAT_PENDING_REQUEST_CODE,
+            intent,
+            pendingIntentFlags
+        )
+    }
+
+    private fun makeSignalLauncherPendingIntent(): PendingIntent {
+        val intent = createMainIntent()
+        val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_ONE_SHOT
+        } else {
+            PendingIntent.FLAG_ONE_SHOT
+        }
+
+        return PendingIntent.getActivity(
+            context,
+            SIGNAL_PENDING_REQUEST_CODE,
             intent,
             pendingIntentFlags
         )
     }
 
     companion object {
-        private const val PENDING_REQUEST_CODE = 1
+        private const val SIGNAL_PENDING_REQUEST_CODE = 1
+        private const val CHAT_PENDING_REQUEST_CODE = 2
     }
 }

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
@@ -1,0 +1,72 @@
+package com.mashup.ssamd.notification.builder
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.mashup.presentation.navigation.MainActivity
+import com.mashup.ssamd.R
+import com.mashup.ssamd.notification.NotificationConfigs
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/08/01
+ */
+class NotificationBuilderImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : NotificationBuilder {
+
+    override fun showReceivedSignalNotification(title: String, body: String) {
+        NotificationConfigs.notifyReceivedSignal(context) {
+            setSmallIcon(R.mipmap.ic_launcher)
+            setWhen(1)
+            setContentTitle("title")
+            setContentText("body")
+            priority = NotificationCompat.PRIORITY_HIGH
+            setAutoCancel(true)
+            setFullScreenIntent(makeLauncherPendingIntent(), true)
+        }
+    }
+
+    override fun showNewChatNotification() {
+        NotificationConfigs.notifyNewChat(context) {
+            setSmallIcon(R.mipmap.ic_launcher)
+            setWhen(1)
+            setContentTitle("title")
+            setContentText("body")
+            priority = NotificationCompat.PRIORITY_HIGH
+            setAutoCancel(true)
+            setFullScreenIntent(makeLauncherPendingIntent(), true)
+        }
+    }
+
+    private fun createMainIntent(): Intent {
+        return Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+    }
+
+    private fun makeLauncherPendingIntent(): PendingIntent {
+        val intent = createMainIntent()
+        val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT
+        } else {
+            PendingIntent.FLAG_ONE_SHOT
+        }
+
+        return PendingIntent.getActivity(
+            context,
+            PENDING_REQUEST_CODE,
+            intent,
+            pendingIntentFlags
+        )
+    }
+
+    companion object {
+        private const val PENDING_REQUEST_CODE = 1
+    }
+}

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
-import com.mashup.presentation.common.extension.getDisplayedTime
 import com.mashup.presentation.navigation.MainActivity
 import com.mashup.ssamd.R
 import com.mashup.ssamd.notification.NotificationConfigs
@@ -21,44 +20,35 @@ class NotificationBuilderImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : NotificationBuilder {
 
-    override fun showReceivedSignalNotification(
-        title: String,
-        body: String,
-        receivedTimeMillis: String
-    ) {
+    override fun showReceivedSignalNotification(title: String, body: String) {
         NotificationConfigs.notifyReceivedSignal(context) {
             setStyle(NotificationCompat.BigTextStyle().bigText(body))
             setSmallIcon(R.mipmap.ic_launcher)
-            setWhen(receivedTimeMillis.toLong())
             setContentTitle(title)
             setContentText(body)
             priority = NotificationCompat.PRIORITY_HIGH
             setAutoCancel(true)
+            setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             setFullScreenIntent(makeLauncherPendingIntent(), true)
         }
     }
 
-    override fun showNewChatNotification(
-        title: String,
-        body: String,
-        roomId: String,
-        receivedTimeMillis: String
-    ) {
+    override fun showNewChatNotification(title: String, body: String, roomId: String) {
         NotificationConfigs.notifyNewChat(context) {
             setStyle(NotificationCompat.BigTextStyle().bigText(body))
             setSmallIcon(R.mipmap.ic_launcher)
-            setWhen(receivedTimeMillis.toLong())
             setContentTitle(title)
             setContentText(body)
             priority = NotificationCompat.PRIORITY_HIGH
             setAutoCancel(true)
+            setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             setFullScreenIntent(makeLauncherPendingIntent(), true)
         }
     }
 
     private fun createMainIntent(): Intent {
         return Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
     }
 

--- a/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/builder/NotificationBuilderImpl.kt
@@ -30,7 +30,7 @@ class NotificationBuilderImpl @Inject constructor(
             setAutoCancel(true)
             setCategory(NotificationCompat.CATEGORY_MESSAGE)
             setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            setContentIntent(makeChatLauncherPendingIntent())
+            setContentIntent(makeSignalLauncherPendingIntent())
         }
     }
 
@@ -64,7 +64,7 @@ class NotificationBuilderImpl @Inject constructor(
 
         return PendingIntent.getActivity(
             context,
-            CHAT_PENDING_REQUEST_CODE,
+            (System.currentTimeMillis()).toInt(),
             intent,
             pendingIntentFlags
         )
@@ -73,21 +73,16 @@ class NotificationBuilderImpl @Inject constructor(
     private fun makeSignalLauncherPendingIntent(): PendingIntent {
         val intent = createMainIntent()
         val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_ONE_SHOT
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT
         } else {
             PendingIntent.FLAG_ONE_SHOT
         }
 
         return PendingIntent.getActivity(
             context,
-            SIGNAL_PENDING_REQUEST_CODE,
+            (System.currentTimeMillis()).toInt(),
             intent,
             pendingIntentFlags
         )
-    }
-
-    companion object {
-        private const val SIGNAL_PENDING_REQUEST_CODE = 1
-        private const val CHAT_PENDING_REQUEST_CODE = 2
     }
 }

--- a/app/src/main/java/com/mashup/ssamd/notification/di/NotificationModule.kt
+++ b/app/src/main/java/com/mashup/ssamd/notification/di/NotificationModule.kt
@@ -1,0 +1,25 @@
+package com.mashup.ssamd.notification.di
+
+import com.mashup.ssamd.notification.builder.NotificationBuilder
+import com.mashup.ssamd.notification.builder.NotificationBuilderImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/08/01
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+interface NotificationModule {
+
+    @Binds
+    @Singleton
+    fun bindNotificationBuilder(
+        notificationBuilderImpl: NotificationBuilderImpl
+    ): NotificationBuilder
+}

--- a/app/src/release/google-services.json
+++ b/app/src/release/google-services.json
@@ -1,0 +1,47 @@
+{
+  "project_info": {
+    "project_number": "832727038255",
+    "project_id": "keylink-731df",
+    "storage_bucket": "keylink-731df.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:832727038255:android:2a36823f5b6835c29d09da",
+        "android_client_info": {
+          "package_name": "com.mashup.ssamd"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "832727038255-789jestndq3tqhosf2rj0lodgv06ii23.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.mashup.ssamd",
+            "certificate_hash": "1519448b6407650d0d0e6d3fe0c2cb361ddeef68"
+          }
+        },
+        {
+          "client_id": "832727038255-dmmombtpj0n3rjihgu8nsk3didie2h97.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCYzKRoLm4ZdbAGgIJ9kgGtQQCLed_Q37M"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "832727038255-dmmombtpj0n3rjihgu8nsk3didie2h97.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -11,4 +11,5 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
     id 'com.google.dagger.hilt.android' version '2.44' apply false
+    id 'com.google.gms.google-services' version '4.3.15' apply false
 }

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -192,4 +192,10 @@ object Dep {
         const val lottie = "com.airbnb.android:lottie:$lottieVersion"
         const val lottieCompose = "com.airbnb.android:lottie-compose:$lottieVersion"
     }
+
+    object Firebase {
+        const val firebaseBom = "com.google.firebase:firebase-bom:32.2.0"
+        const val analytics = "com.google.firebase:firebase-analytics-ktx:21.3.0"
+        const val cloudMessaging = "com.google.firebase:firebase-messaging-ktx:23.2.0"
+    }
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -81,4 +81,8 @@ dependencies {
     // Pagin3
     implementation Dep.AndroidX.Paging3.pagingRuntime
 
+    // google firebase
+    implementation platform(Dep.Firebase.firebaseBom)
+    implementation Dep.Firebase.cloudMessaging
+
 }

--- a/data/src/main/java/com/mashup/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/mashup/data/di/RepositoryModule.kt
@@ -31,4 +31,8 @@ interface RepositoryModule {
     @Binds
     @Singleton
     fun bindChatRepository(chatRepositoryImpl: ChatRepositoryImpl): ChatRepository
+
+    @Binds
+    @Singleton
+    fun bindFirebaseRepository(firebaseRepositoryImpl: FirebaseRepositoryImpl): FirebaseRepository
 }

--- a/data/src/main/java/com/mashup/data/repository/FirebaseRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/data/repository/FirebaseRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.mashup.data.repository
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.mashup.domain.repository.FirebaseRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/31
+ */
+class FirebaseRepositoryImpl @Inject constructor() : FirebaseRepository {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun getFCMDeviceToken(): String =
+        suspendCancellableCoroutine { cancellableContinuation ->
+            FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+                if (!task.isSuccessful) {
+                    task.exception?.run {
+                        cancellableContinuation.cancel(this)
+                    }
+                }
+                val fcmDeviceToken = task.result
+                cancellableContinuation.resume(fcmDeviceToken) {}
+            }
+        }
+}

--- a/domain/src/main/java/com/mashup/domain/repository/FirebaseRepository.kt
+++ b/domain/src/main/java/com/mashup/domain/repository/FirebaseRepository.kt
@@ -1,0 +1,11 @@
+package com.mashup.domain.repository
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/07/31
+ */
+interface FirebaseRepository {
+
+    suspend fun getFCMDeviceToken(): String
+}

--- a/domain/src/main/java/com/mashup/domain/usecase/GetFCMDeviceTokenUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/GetFCMDeviceTokenUseCase.kt
@@ -1,0 +1,18 @@
+package com.mashup.domain.usecase
+
+import com.mashup.domain.repository.FirebaseRepository
+import com.mashup.domain.usecase.common.CoroutineUseCase
+import javax.inject.Inject
+
+/**
+ * Ssam_D_Android
+ * @author jaesung
+ * @created 2023/08/02
+ */
+class GetFCMDeviceTokenUseCase @Inject constructor(
+    private val firebaseRepository: FirebaseRepository
+) : CoroutineUseCase<Unit, String>() {
+    override suspend fun invoke(param: Unit): String {
+        return firebaseRepository.getFCMDeviceToken()
+    }
+}

--- a/presentation/src/main/java/com/mashup/presentation/feature/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/login/LoginActivity.kt
@@ -34,6 +34,7 @@ class LoginActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         initObservers()
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        loginViewModel.checkScreenType()
         setThemeContent {
             LoginRoute(
                 loginButtonClicked = { handleKakaoLogin() },
@@ -48,10 +49,10 @@ class LoginActivity : ComponentActivity() {
         observeState()
     }
 
-    override fun onStart() {
-        super.onStart()
-        loginViewModel.checkScreenType()
-    }
+//    override fun onStart() {
+//        super.onStart()
+//        loginViewModel.checkScreenType()
+//    }
 
     private fun observeState() {
         lifecycleScope.launch {

--- a/presentation/src/main/java/com/mashup/presentation/feature/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/login/LoginViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mashup.domain.exception.ConflictException
+import com.mashup.domain.usecase.GetFCMDeviceTokenUseCase
 import com.mashup.domain.usecase.login.*
 import com.mashup.presentation.ui.common.ValidationState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,7 +20,8 @@ class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
     private val checkNicknameDuplicationUseCase: CheckNicknameDuplicationUseCase,
     private val patchNicknameUseCase: PatchNicknameUseCase,
-    private val getEntryScreenTypeUseCase: GetEntryScreenTypeUseCase
+    private val getEntryScreenTypeUseCase: GetEntryScreenTypeUseCase,
+    private val getFCMDeviceTokenUseCase: GetFCMDeviceTokenUseCase,
 ) : ViewModel() {
 
 //    init {
@@ -53,9 +55,13 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    fun login(email: String?, socialId: String, deviceToken: String? = "") {
+    fun login(email: String?, socialId: String) {
         viewModelScope.launch {
-            val param = LoginParam(email = email, socialId = socialId, deviceToken = deviceToken)
+            val param = LoginParam(
+                email = email,
+                socialId = socialId,
+                deviceToken = getFCMDeviceTokenUseCase.execute(Unit)
+            )
             loginUseCase.execute(param)
                 .onSuccess {
                     checkScreenType()

--- a/presentation/src/main/java/com/mashup/presentation/feature/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/login/LoginViewModel.kt
@@ -22,9 +22,9 @@ class LoginViewModel @Inject constructor(
     private val getEntryScreenTypeUseCase: GetEntryScreenTypeUseCase
 ) : ViewModel() {
 
-    init {
-        checkScreenType()
-    }
+//    init {
+//        checkScreenType()
+//    }
 
     var currentPage by mutableStateOf(0)
     var nickname by mutableStateOf("")


### PR DESCRIPTION
## 작업 내역

- #170 
- #254 

## To. Reviewer

- 로그인 시 FCM 디바이스 토큰 전달 됩니다
- Android13 실기기로 테스트를 못해봤어요 이거 한번 확인 필요합니당
- 채팅 알림의 경우 채팅 메시지가 최대 300자가 올 수 있기 때문에 BigTextStyle 적용해놨는데 일단은 구독 키워드 알림에도 동일하게 적용된 상태입니다
- 채팅 클릭 시 화면 이동은 우선 Main입니당 자세한 이유는 이따 회의때.. ㄱㄱ
- 08.03 update 
  - remote message를 data에서 모두 파싱해서 백그라운드, 포그라운드 동일하게 onMessageReceived 타게끔 수정했습니당

## 화면
| 기능     | 포그라운드 | 백그라운드 |
|--------|--------|--------|
| 구독 키워드 푸쉬 알림 | <img src="https://github.com/mash-up-kr/ssam-d-Android/assets/51078673/b21a5ba9-2b2d-49c1-a297-d5cd7f3c736c" width=300 /> | <img src="https://github.com/mash-up-kr/ssam-d-Android/assets/51078673/2e6d2651-3e9b-4fe6-ab97-61be2e49d1e5" width=300 /> |
| 채팅 푸쉬 알림 | <img src="https://github.com/mash-up-kr/ssam-d-Android/assets/51078673/93f5079f-25fc-477d-8cb4-ab74abdda5a8" width=300 /> | <img src="https://github.com/mash-up-kr/ssam-d-Android/assets/51078673/f3a2d14b-952d-472c-8787-40c4c3940080" width=300 /> |





## 관련 이슈
close #170 
close #254 
