### PR TITLE
#271 화면 별 키보드 처리

### DIFF
--- a/presentation/src/main/java/com/mashup/presentation/feature/onboarding/OnBoardingScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/onboarding/OnBoardingScreen.kt
@@ -3,11 +3,14 @@ package com.mashup.presentation.feature.onboarding
 import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.*
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -105,10 +108,16 @@ fun OnBoardingContent(
     removeKeyword: (Int) -> Unit,
     saveKeywords: (List<String>) -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = modifier
             .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            }
             .padding(horizontal = 20.dp),
     ) {
         KeywordScreen(
@@ -125,6 +134,7 @@ fun OnBoardingContent(
                 .padding(vertical = 12.dp),
             text = stringResource(id = R.string.onboarding_keywords_complete),
             onClick = {
+                focusManager.clearFocus()
                 saveKeywords(keywords)
             },
             enable = keywords.isNotEmpty()

--- a/presentation/src/main/java/com/mashup/presentation/feature/reply/ReplyContent.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/reply/ReplyContent.kt
@@ -1,14 +1,14 @@
 package com.mashup.presentation.feature.reply
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -34,32 +34,40 @@ fun ReplyContent(
 ) {
     val scrollState = rememberScrollState()
     val snackbarMessage = stringResource(R.string.snackbar_reply)
+    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            }
     ) {
-        KeyLinkTextField(
-            modifier = Modifier
-                .fillMaxSize()
-                .weight(1f),
-            value = reply,
-            onValueChange = { reply ->
-                if (reply.length >= MAX_LENGTH) onLengthOver()
-                else onReplyTextChange(reply)
-            },
-            hint = stringResource(id = R.string.hint_signal_content),
-            hintAlign = TextAlign.Start,
-            maxLength = 300
-        )
+        Box(
+            modifier = Modifier.weight(1f)
+        ) {
+            KeyLinkTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = reply,
+                onValueChange = { reply ->
+                    if (reply.length >= MAX_LENGTH) onLengthOver()
+                    else onReplyTextChange(reply)
+                },
+                hint = stringResource(id = R.string.hint_signal_content),
+                hintAlign = TextAlign.Start,
+                maxLength = 300
+            )
+        }
         KeyLinkButton(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 20.dp)
-                .padding(bottom = 48.dp),
+                .padding(vertical = 12.dp, horizontal = 20.dp),
             text = stringResource(id = R.string.button_send_reply),
             onClick = {
+                focusManager.clearFocus()
                 onShowSnackbar(snackbarMessage, SnackbarDuration.Short)
                 onSendClick()
             },

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalCompleteScreen.kt
@@ -65,7 +65,7 @@ fun SignalCompleteScreen(
             text = stringResource(id = R.string.close),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 48.dp, start = 20.dp, end = 20.dp),
+                .padding(vertical = 12.dp, horizontal = 20.dp),
             backgroundColor = Gray02,
             contentColor = Gray06,
             enable = true,

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
@@ -60,17 +60,8 @@ fun SignalContentScreen(
     modifier: Modifier = Modifier
 ) {
     var dialogState by rememberSaveable { mutableStateOf(false) }
-    val focusManager = LocalFocusManager.current
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                detectTapGestures(onTap = {
-                    focusManager.clearFocus()
-                })
-            }
-    ) {
+    Column(modifier = modifier.fillMaxSize()) {
         KeyLinkToolbar(
             title = {
                 Text(
@@ -85,10 +76,7 @@ fun SignalContentScreen(
         SignalContent(
             modifier = modifier,
             signalContent = signalContent,
-            onNextClick = {
-                focusManager.clearFocus()
-                onNextClick()
-            },
+            onNextClick = onNextClick,
             onLengthOver = { dialogState = true },
             onSignalChange = onSignalChange
         )
@@ -111,11 +99,17 @@ fun SignalContent(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
+    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            }
     ) {
         Box(
             modifier = Modifier.weight(1f)
@@ -137,7 +131,10 @@ fun SignalContent(
                 .fillMaxWidth()
                 .padding(vertical = 12.dp, horizontal = 20.dp),
             text = stringResource(id = R.string.next),
-            onClick = onNextClick,
+            onClick = {
+                focusManager.clearFocus()
+                onNextClick()
+            },
             enable = signalContent.isNotEmpty()
         )
     }

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -98,8 +99,8 @@ fun SignalContent(
     onSignalChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
     val scrollState = rememberScrollState()
+    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = modifier
@@ -122,10 +123,12 @@ fun SignalContent(
         KeyLinkButton(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 20.dp)
-                .padding(bottom = 48.dp),
+                .padding(vertical = 12.dp, horizontal = 20.dp),
             text = stringResource(id = R.string.next),
-            onClick = onNextClick,
+            onClick = {
+                focusManager.clearFocus()
+                onNextClick()
+            },
             enable = signalContent.isNotEmpty()
         )
     }

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalContentScreen.kt
@@ -1,9 +1,7 @@
 package com.mashup.presentation.feature.signal.send.compose
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
@@ -13,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -61,8 +60,17 @@ fun SignalContentScreen(
     modifier: Modifier = Modifier
 ) {
     var dialogState by rememberSaveable { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            }
+    ) {
         KeyLinkToolbar(
             title = {
                 Text(
@@ -77,7 +85,10 @@ fun SignalContentScreen(
         SignalContent(
             modifier = modifier,
             signalContent = signalContent,
-            onNextClick = onNextClick,
+            onNextClick = {
+                focusManager.clearFocus()
+                onNextClick()
+            },
             onLengthOver = { dialogState = true },
             onSignalChange = onSignalChange
         )
@@ -100,35 +111,33 @@ fun SignalContent(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
-    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
     ) {
-        KeyLinkTextField(
-            modifier = Modifier
-                .fillMaxSize()
-                .weight(1f),
-            value = signalContent,
-            onValueChange = { text ->
-                if (text.length >= 300) onLengthOver()
-                else onSignalChange(text)
-            },
-            hint = stringResource(id = R.string.hint_signal_content),
-            hintAlign = TextAlign.Start,
-            maxLength = 300
-        )
+        Box(
+            modifier = Modifier.weight(1f)
+        ) {
+            KeyLinkTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = signalContent,
+                onValueChange = { text ->
+                    if (text.length >= 300) onLengthOver()
+                    else onSignalChange(text)
+                },
+                hint = stringResource(id = R.string.hint_signal_content),
+                hintAlign = TextAlign.Start,
+                maxLength = 300
+            )
+        }
         KeyLinkButton(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 12.dp, horizontal = 20.dp),
             text = stringResource(id = R.string.next),
-            onClick = {
-                focusManager.clearFocus()
-                onNextClick()
-            },
+            onClick = onNextClick,
             enable = signalContent.isNotEmpty()
         )
     }

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalKeywordScreen.kt
@@ -25,10 +25,7 @@ import com.mashup.presentation.feature.signal.send.KeywordUiState
 import com.mashup.presentation.feature.signal.send.SignalUiEvent
 import com.mashup.presentation.feature.signal.send.SignalViewModel
 import com.mashup.presentation.ui.common.*
-import com.mashup.presentation.ui.theme.Black
-import com.mashup.presentation.ui.theme.Gray06
-import com.mashup.presentation.ui.theme.SsamDTheme
-import com.mashup.presentation.ui.theme.White
+import com.mashup.presentation.ui.theme.*
 import okhttp3.internal.toImmutableList
 
 /**
@@ -187,11 +184,8 @@ fun SignalKeyword(
     Column(modifier = modifier.fillMaxSize()) {
         Text(
             text = stringResource(R.string.signal_keyword_title),
-            style = TextStyle(
-                fontSize = 22.sp,
-                color = White,
-                fontWeight = FontWeight.Bold
-            ),
+            style = Heading3,
+            color = White
         )
 
         Text(

--- a/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/signal/send/compose/SignalKeywordScreen.kt
@@ -1,6 +1,7 @@
 package com.mashup.presentation.feature.signal.send.compose
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -9,6 +10,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -81,6 +84,7 @@ fun SignalKeywordScreen(
 ) {
     var keyword by rememberSaveable { mutableStateOf("") }
     var showGoBackDialog by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
 
     BackHandler(true) {
         showGoBackDialog = true
@@ -96,21 +100,21 @@ fun SignalKeywordScreen(
         }
     ) { paddingValues ->
         val innerPaddingValues = PaddingValues(
-            top = paddingValues.calculateTopPadding() + 8.dp,
+            top = paddingValues.calculateTopPadding(),
             start = 20.dp,
             end = 20.dp
         )
 
         when (keywordUiState) {
             is KeywordUiState.Loading -> {
-                Column(modifier = Modifier.padding(innerPaddingValues)) {
+                Column(modifier = Modifier.padding(innerPaddingValues).padding(top = 8.dp)) {
                     ShimmerScreen(
                         modifier = Modifier.weight(1f)
                     )
                     KeyLinkButton(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 48.dp),
+                            .padding(vertical = 12.dp),
                         text = stringResource(R.string.button_send_signal),
                         enable = false,
                         onClick = onSendClick
@@ -118,7 +122,15 @@ fun SignalKeywordScreen(
                 }
             }
             is KeywordUiState.Success -> {
-                Column(modifier = Modifier.padding(innerPaddingValues)) {
+                Column(
+                    modifier = Modifier
+                        .padding(innerPaddingValues)
+                        .pointerInput(Unit) {
+                            detectTapGestures(onTap = {
+                                focusManager.clearFocus()
+                            })
+                        }
+                ) {
                     SignalKeyword(
                         modifier = Modifier.weight(1f),
                         keywords = keywords,
@@ -131,10 +143,13 @@ fun SignalKeywordScreen(
                     KeyLinkButton(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 48.dp),
+                            .padding(vertical = 12.dp),
                         text = stringResource(R.string.button_send_signal),
                         enable = keywords.isNotEmpty(),
-                        onClick = onSendClick
+                        onClick = {
+                            focusManager.clearFocus()
+                            onSendClick()
+                        }
                     )
                 }
             }
@@ -191,7 +206,7 @@ fun SignalKeyword(
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
-                .padding(top = 28.dp)
+                .padding(top = 20.dp)
                 .verticalScroll(scrollState)
         ) {
             keywords.forEachIndexed { i, keyword ->

--- a/presentation/src/main/java/com/mashup/presentation/feature/subscribe/SubscribeKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/subscribe/SubscribeKeywordScreen.kt
@@ -1,6 +1,7 @@
 package com.mashup.presentation.feature.subscribe
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -8,6 +9,8 @@ import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -71,12 +74,21 @@ fun SubscribeKeywordScreen(
     val keywords = remember { mutableStateListOf<String>() }
     var showGoBackDialog by remember { mutableStateOf(false) }
     val snackbarMessage = stringResource(id = R.string.snackbar_subscribe_keyword)
+    val focusManager = LocalFocusManager.current
 
     BackHandler(true) {
         showGoBackDialog = true
     }
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+            detectTapGestures(onTap = {
+                focusManager.clearFocus()
+            })
+        }
+    ) {
         KeyLinkToolbar(
             onClickBack = { showGoBackDialog = true }
         )
@@ -90,9 +102,10 @@ fun SubscribeKeywordScreen(
             text = stringResource(R.string.button_save),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 12.dp, start = 20.dp, end = 20.dp),
+                .padding(vertical = 12.dp, horizontal = 20.dp),
             enable = subscribeKeywords.isNotEmpty(),
             onClick = {
+                focusManager.clearFocus()
                 onShowSnackbar(snackbarMessage, SnackbarDuration.Short)
                 onSaveButtonClick()
             }
@@ -142,7 +155,7 @@ fun SubscribeKeywordContent(
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
-                .padding(top = 28.dp)
+                .padding(top = 20.dp)
                 .verticalScroll(scrollState)
         ) {
             keywords.forEachIndexed { i, keyword ->

--- a/presentation/src/main/java/com/mashup/presentation/feature/subscribe/SubscribeKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/presentation/feature/subscribe/SubscribeKeywordScreen.kt
@@ -80,20 +80,18 @@ fun SubscribeKeywordScreen(
         showGoBackDialog = true
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-            detectTapGestures(onTap = {
-                focusManager.clearFocus()
-            })
-        }
-    ) {
+    Column(modifier = modifier.fillMaxSize()) {
         KeyLinkToolbar(
             onClickBack = { showGoBackDialog = true }
         )
         SubscribeKeywordContent(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
             keywords = subscribeKeywords,
             onKeywordAdd = onAddKeyword,
             onKeywordDelete = onDeleteKeyword
@@ -138,7 +136,7 @@ fun SubscribeKeywordContent(
         scrollState.animateScrollTo(Int.MAX_VALUE)
     }
 
-    Column(modifier = modifier.padding(top = 8.dp, start = 20.dp, end = 20.dp)) {
+    Column(modifier = modifier.padding(horizontal = 20.dp)) {
         Text(
             text = stringResource(R.string.subscribe_keyword_title),
             style = Heading3,

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mashup.presentation.ui.theme.*
+import kotlinx.coroutines.delay
 
 @Composable
 fun KeyLinkTextField(
@@ -148,6 +149,13 @@ fun KeyLinkBoxTextField(
     fontSize: TextUnit,
     validationState: ValidationState
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(true) {
+        delay(300)
+        focusRequester.requestFocus()
+    }
+
     Column(
         modifier = modifier
     ) {
@@ -167,7 +175,8 @@ fun KeyLinkBoxTextField(
                 .padding(
                     horizontal = 16.dp,
                     vertical = 15.dp
-                ),
+                )
+                .focusRequester(focusRequester),
             value = value,
             onValueChange = {
                 if (maxLength == 0 || it.length <= maxLength) {

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkTextField.kt
@@ -35,8 +35,14 @@ fun KeyLinkTextField(
     hintAlign: TextAlign = TextAlign.Center,
     maxLength: Int = 0,
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
     TextField(
-        modifier = modifier,
+        modifier = modifier.focusRequester(focusRequester),
         value = value,
         onValueChange = {
             if (maxLength == 0 || it.length <= maxLength) {

--- a/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkToolbar.kt
+++ b/presentation/src/main/java/com/mashup/presentation/ui/common/KeyLinkToolbar.kt
@@ -1,5 +1,6 @@
 package com.mashup.presentation.ui.common
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -7,6 +8,8 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.mashup.presentation.R
@@ -15,11 +18,14 @@ import com.mashup.presentation.ui.theme.White
 
 @Composable
 fun KeyLinkToolbar(
+    modifier: Modifier = Modifier,
     title: @Composable () -> Unit = {},
     menuAction: @Composable () -> Unit = {},
     onClickBack: () -> Unit = {},
     backgroundColor: Color = Black,
 ) {
+    val focusManager = LocalFocusManager.current
+
     TopAppBar(
         title = title,
         backgroundColor = backgroundColor,
@@ -35,7 +41,13 @@ fun KeyLinkToolbar(
         actions = {
             menuAction()
         },
-        modifier = Modifier.height(52.dp),
+        modifier = modifier
+            .height(52.dp)
+            .pointerInput(Unit) {
+            detectTapGestures(onTap = {
+                focusManager.clearFocus()
+            })
+        },
         elevation = 0.dp
     )
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="disconnect">끊기</string>
     <string name="hint_signal_content">오늘의 날씨, 기분, 나눈 대화들을 누군가에게 전달해보세요. 대화는 1:1로 프라이빗하게 이루어집니다.</string>
     <string name="signal_keyword_title">전달할 키워드를 확인해주세요</string>
-    <string name="signal_keyword_subtitle">시그널은 키워드를 구독한 상대에게 전달돼요</string>
+    <string name="signal_keyword_subtitle">시그널은 아래 키워드를 구독중인 상대에게 전달됩니다</string>
 
     // 온보딩
     <string name="onboarding_keywords_complete">모두 입력했어요</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -53,8 +53,8 @@
     <string name="exit">나가기</string>
     <string name="disconnect">끊기</string>
     <string name="hint_signal_content">오늘의 날씨, 기분, 나눈 대화들을 누군가에게 전달해보세요. 대화는 1:1로 프라이빗하게 이루어집니다.</string>
-    <string name="signal_keyword_title">키워드를 확인해주세요</string>
-    <string name="signal_keyword_subtitle">해당 키워드는 구독한 상대에게 전달돼요</string>
+    <string name="signal_keyword_title">전달할 키워드를 확인해주세요</string>
+    <string name="signal_keyword_subtitle">시그널은 키워드를 구독한 상대에게 전달돼요</string>
 
     // 온보딩
     <string name="onboarding_keywords_complete">모두 입력했어요</string>
@@ -99,7 +99,7 @@
     <string name="subscribe_keyword_subtitle">키워드를 확인하고 시그널을 받아보세요</string>
     <string name="button_save">저장하기</string>
     <string name="content_description_snackbar_icon">스낵바 아이콘입니다.</string>
-    <string name="text_field_hint">#일상 #커리어</string>
+    <string name="text_field_hint">예) 일상, 커리어</string>
     <string name="signal_matched_count">%s개 일치</string>
     <string name="bottom_sheet_disconnect">시그널 끊기</string>
     <string name="bottom_sheet_declare">신고하기</string>


### PR DESCRIPTION
## 작업 내역

- https://github.com/mash-up-kr/ssam-d-Android/issues/271

## To. Reviewer

- 가로로 꽉 차있는 버튼들을 다 밑에 붙어있는? 형태로 ui도 쪼금 손봤슴다
- 시그널 보내기 > 키워드 입력 화면 문구 수정도 완
- 닉네임 화면은.. pager라서 다른 화면들처럼 requesetFocus를 바로 하면 페이지가 넘어가다가 멈춰서 키보드가 올라가더라구
 페이지 전환이 끝나는 상태를 알 수 있는 방법 찾아보다가 일단 delay를 줬다는 ..

## 화면
| 기능     | 화면     |
|--------|--------|
| 키보드 처리 | 

https://github.com/mash-up-kr/ssam-d-Android/assets/51108983/7e2b59d4-233b-4712-bee5-d4dd3a969aaa


## 관련 이슈
close #271 
